### PR TITLE
Auto style check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,5 @@ install:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dmaven.compiler.showDeprecation=true
 script:
   - mvn test -B -Dmaven.javadoc.skip=true
-  ############################################
-  ### STYLE ENFORCEMENT CURRENTLY DISABLED ###
-  ############################################
-  ### Much work required to fix the code   ###
-  ### style before this can be turned on   ###
-  ### on a main branch.                    ###
-  ############################################
-  # - mvn checkstyle:check -Dmaven.javadoc.skip=true
+  - mvn checkstyle:check -Dmaven.javadoc.skip=true
   - mvn javadoc:javadoc

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/job_parameters/GitPyNNJobParametersFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/job_parameters/GitPyNNJobParametersFactory.java
@@ -48,7 +48,7 @@ class GitPyNNJobParametersFactory extends JobParametersFactory {
         }
     }
 
-    /** Constructs the parameters by checking out the git repository */
+    /** Constructs the parameters by checking out the git repository. */
     private JobParameters constructParameters(final Job job,
             final File workingDirectory, final String experimentDescription)
             throws GitAPIException, InvalidRemoteException, TransportException,

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/job_parameters/JobParametersFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/job_parameters/JobParametersFactory.java
@@ -7,7 +7,7 @@ import uk.ac.manchester.cs.spinnaker.job.JobParameters;
 import uk.ac.manchester.cs.spinnaker.job.nmpi.Job;
 
 /**
- * A factory that produces job parameters
+ * A factory that produces job parameters.
  */
 public abstract class JobParametersFactory {
     /**

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/job_parameters/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/job_parameters/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The parameters used to launch a job.
+ */
+package uk.ac.manchester.cs.spinnaker.job_parameters;

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/JobProcess.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/JobProcess.java
@@ -8,7 +8,7 @@ import uk.ac.manchester.cs.spinnaker.job.Status;
 import uk.ac.manchester.cs.spinnaker.machine.SpinnakerMachine;
 
 /**
- * An interface to an executable job process type
+ * An interface to an executable job process type.
  *
  * @param <P>
  *            The type of the parameters
@@ -63,7 +63,7 @@ public interface JobProcess<P extends JobParameters> {
     List<ProvenanceItem> getProvenance();
 
     /**
-     * Cleans up the job, removing any associated files
+     * Cleans up the job, removing any associated files.
      */
     void cleanup();
 }

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/JobProcessFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/JobProcessFactory.java
@@ -9,7 +9,7 @@ import uk.ac.manchester.cs.spinnaker.job.JobParameters;
 
 /**
  * A factory for creating {@link JobProcess} instances given a
- * {@link JobParameters} instance
+ * {@link JobParameters} instance.
  */
 public class JobProcessFactory {
     private final ThreadGroup threadGroup;

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
@@ -44,7 +44,7 @@ import uk.ac.manchester.cs.spinnaker.machine.SpinnakerMachine;
 import uk.ac.manchester.cs.spinnaker.utils.ThreadUtils;
 
 /**
- * A process for running PyNN jobs
+ * A process for running PyNN jobs.
  */
 public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
     private static final String PROVENANCE_DIRECTORY = "provenance_data";
@@ -149,10 +149,10 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
             }
 
             // If the exit is an error, mark an error
-            if (exitValue > 127) {
+            if (exitValue >= MIN_SIGNAL_OFFSET) {
                 // Useful to distinguish this case
                 throw new Exception("Python exited with signal ("
-                        + (exitValue - 128) + ")");
+                        + (exitValue - MIN_SIGNAL_OFFSET) + ")");
             }
             if (exitValue != 0) {
                 throw new Exception("Python exited with a non-zero code ("
@@ -165,6 +165,8 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
             status = Error;
         }
     }
+
+    private static final int MIN_SIGNAL_OFFSET = 128;
 
     /** How to actually run a subprocess. */
     private int runSubprocess(final PyNNJobParameters parameters,
@@ -245,12 +247,14 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
         }
     }
 
+    private static final int BUFFER_SIZE = 8 * 1024;
+
     private void zipProvenance(final ZipOutputStream reportsZip,
             final File directory, final String path)
             throws IOException, JAXBException {
 
         // Go through the report files and zip them up
-        final byte[] buffer = new byte[8196];
+        final byte[] buffer = new byte[BUFFER_SIZE];
         for (final File file : directory.listFiles()) {
             if (file.isDirectory()) {
                 zipProvenance(reportsZip, file, path + "/" + file.getName());
@@ -332,7 +336,7 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
          * @param writer
          *            The writer to write to
          */
-        public ReaderLogWriter(final Reader reader, final LogWriter writer) {
+        ReaderLogWriter(final Reader reader, final LogWriter writer) {
             super(threadGroup, "Reader Log Writer");
             requireNonNull(reader);
             if (reader instanceof BufferedReader) {
@@ -353,10 +357,9 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
          * @param writer
          *            The writer to write to.
          */
-        public ReaderLogWriter(final InputStream input,
-                final LogWriter writer) {
-            this(new InputStreamReader(input), writer);
-        }
+		ReaderLogWriter(final InputStream input, final LogWriter writer) {
+			this(new InputStreamReader(input), writer);
+		}
 
         @Override
         public void run() {
@@ -389,7 +392,7 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
         }
 
         /**
-         * Closes the reader/writer
+         * Closes the reader/writer.
          */
         @Override
         public void close() {

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
@@ -357,9 +357,9 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
          * @param writer
          *            The writer to write to.
          */
-		ReaderLogWriter(final InputStream input, final LogWriter writer) {
-			this(new InputStreamReader(input), writer);
-		}
+        ReaderLogWriter(final InputStream input, final LogWriter writer) {
+            this(new InputStreamReader(input), writer);
+        }
 
         @Override
         public void run() {

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The handles for running jobs.
+ */
+package uk.ac.manchester.cs.spinnaker.jobprocess;

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The main job process manager code.
+ */
+package uk.ac.manchester.cs.spinnaker.jobprocessmanager;

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/FileDownloader.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/FileDownloader.java
@@ -23,8 +23,11 @@ import javax.net.ssl.X509TrustManager;
 import org.apache.commons.codec.binary.Base64;
 import org.jboss.resteasy.util.ParameterParser;
 
-public class FileDownloader {
-    private static String getFileName(final String contentDisposition) {
+public abstract class FileDownloader {
+	private FileDownloader() {
+	}
+
+	private static String getFileName(final String contentDisposition) {
         if (contentDisposition != null) {
             final String cdl = contentDisposition.toLowerCase();
             if (cdl.startsWith("form-data") || cdl.startsWith("attachment")) {
@@ -130,7 +133,7 @@ public class FileDownloader {
         // Set up to trust everyone
         try {
             SSLContext sc = SSLContext.getInstance("SSL");
-            sc.init(null, new TrustManager[]{new X509TrustManager() {
+            TrustManager tm = new X509TrustManager() {
                 @Override
                 public X509Certificate[] getAcceptedIssuers() {
                     return null;
@@ -145,7 +148,8 @@ public class FileDownloader {
                 public void checkServerTrusted(X509Certificate[] certs,
                         String authType) {
                 }
-            }}, new SecureRandom());
+            };
+            sc.init(null, new TrustManager[] {tm}, new SecureRandom());
 
             connection.setSSLSocketFactory(sc.getSocketFactory());
             connection.setHostnameVerifier(new HostnameVerifier() {

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/FileDownloader.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/FileDownloader.java
@@ -24,10 +24,10 @@ import org.apache.commons.codec.binary.Base64;
 import org.jboss.resteasy.util.ParameterParser;
 
 public abstract class FileDownloader {
-	private FileDownloader() {
-	}
+    private FileDownloader() {
+    }
 
-	private static String getFileName(final String contentDisposition) {
+    private static String getFileName(final String contentDisposition) {
         if (contentDisposition != null) {
             final String cdl = contentDisposition.toLowerCase();
             if (cdl.startsWith("form-data") || cdl.startsWith("attachment")) {

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/Log.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/Log.java
@@ -1,7 +1,10 @@
 package uk.ac.manchester.cs.spinnaker.utils;
 
-public class Log {
-    public static void log(final String message) {
+public abstract class Log {
+	private Log() {
+	}
+
+	public static void log(final String message) {
         System.err.println(message);
     }
 

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/Log.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/Log.java
@@ -1,10 +1,10 @@
 package uk.ac.manchester.cs.spinnaker.utils;
 
 public abstract class Log {
-	private Log() {
-	}
+    private Log() {
+    }
 
-	public static void log(final String message) {
+    public static void log(final String message) {
         System.err.println(message);
     }
 

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/ThreadUtils.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/ThreadUtils.java
@@ -5,18 +5,18 @@ public abstract class ThreadUtils {
     }
 
     /**
-     * Recommended way of doing "quiet" sleeps.
-     *
-     * @param delay
-     *          How long to sleep for, in milliseconds.
-     * @see <a href=
-     *      "http://stackoverflow.com/questions/1087475/when-does-javas-thread-sleep-throw-interruptedexception"
-     *      >stackoverflow.com/.../when-does-javas-thread-sleep-throw-interruptedexception</a>
-     */
-    public static void sleep(final long delay) {
+	 * Recommended way of doing "quiet" sleeps.
+	 *
+	 * @param delay
+	 *            How long to sleep for, in milliseconds.
+	 * @see <a href="https://stackoverflow.com/q/1087475/301832">Stack Overflow
+	 *      Question: When does Java's Thread.sleep throw
+	 *      InterruptedException?</a>
+	 */
+    public static void sleep(long delay) {
         try {
             Thread.sleep(delay);
-        } catch (final InterruptedException e) {
+        } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
     }

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/ThreadUtils.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/ThreadUtils.java
@@ -5,14 +5,14 @@ public abstract class ThreadUtils {
     }
 
     /**
-	 * Recommended way of doing "quiet" sleeps.
-	 *
-	 * @param delay
-	 *            How long to sleep for, in milliseconds.
-	 * @see <a href="https://stackoverflow.com/q/1087475/301832">Stack Overflow
-	 *      Question: When does Java's Thread.sleep throw
-	 *      InterruptedException?</a>
-	 */
+     * Recommended way of doing "quiet" sleeps.
+     *
+     * @param delay
+     *            How long to sleep for, in milliseconds.
+     * @see <a href="https://stackoverflow.com/q/1087475/301832">Stack Overflow
+     *      Question: When does Java's Thread.sleep throw
+     *      InterruptedException?</a>
+     */
     public static void sleep(long delay) {
         try {
             Thread.sleep(delay);

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Miscellaneous utilities.
+ */
+package uk.ac.manchester.cs.spinnaker.utils;

--- a/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/job/JobParametersTypeName.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/job/JobParametersTypeName.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
 @Target(TYPE)
 public @interface JobParametersTypeName {
     /**
-     * The type name
+     * The type name.
      *
      * @return The type name
      */

--- a/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/job/nmpi/Job.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/job/nmpi/Job.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
- * A NMPI job
+ * A NMPI job.
  */
 public class Job implements QueueNextResponse {
     private String code;

--- a/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/job/nmpi/QueueEmpty.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/job/nmpi/QueueEmpty.java
@@ -1,7 +1,7 @@
 package uk.ac.manchester.cs.spinnaker.job.nmpi;
 
 /**
- * A message indicating that the queue is empty
+ * A message indicating that the queue is empty.
  */
 public class QueueEmpty implements QueueNextResponse {
     private String warning;

--- a/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/job/nmpi/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/job/nmpi/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * The description of SpiNNaker jobs based on the HBP NMPI. The Human Brain
+ * Project's NeuroMorphic Platform Interface is documented elsewhere.
+ */
+package uk.ac.manchester.cs.spinnaker.job.nmpi;

--- a/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/job/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/job/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The description of SpiNNaker jobs.
+ */
+package uk.ac.manchester.cs.spinnaker.job;

--- a/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/job/pynn/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/job/pynn/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The description of parameters for SpiNNaker jobs that use PyNN.
+ */
+package uk.ac.manchester.cs.spinnaker.job.pynn;

--- a/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/machine/SpinnakerMachine.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/machine/SpinnakerMachine.java
@@ -14,41 +14,43 @@ public class SpinnakerMachine
     private static final long serialVersionUID = -2247744763327978524L;
 
     /**
-     * The name of the machine
+     * The name of the machine.
      */
     private String machineName = null;
 
     /**
-     * The version of the machine
+     * The version of the machine.
      */
     private String version = null;
 
     /**
-     * The width of the machine
+     * The width of the machine.
      */
     private int width = 0;
 
     /**
-     * The height of the machine
+     * The height of the machine.
      */
     private int height = 0;
 
     /**
-     * The number of boards in the machine
+     * The number of boards in the machine.
      */
     private int nBoards = 0;
 
     /**
-     * The BMP details of the machine
+     * The BMP details of the machine.
      */
     private String bmpDetails = null;
 
     /**
-     * Creates an empty machine
+     * Creates an empty machine.
      */
     public SpinnakerMachine() {
         // Does Nothing
     }
+
+    private static final int EXPECTED_NUM_PARTS = 6;
 
     /**
      * Creates a new Spinnaker Machine by parsing the name of a machine.
@@ -64,15 +66,16 @@ public class SpinnakerMachine
 
         final String[] parts =
                 value.substring(1, value.length() - 1).split(":");
-        if (parts.length != 6) {
+        if (parts.length != EXPECTED_NUM_PARTS) {
             throw new IllegalArgumentException(
                     "Wrong number of :-separated arguments - " + parts.length
                             + " found but 6 required");
         }
 
-        return new SpinnakerMachine(parts[0].trim(), parts[1].trim(),
-                parseInt(parts[2].trim()), parseInt(parts[3].trim()),
-                parseInt(parts[4].trim()), parts[4].trim());
+        int i = 0;
+        return new SpinnakerMachine(parts[i++].trim(), parts[i++].trim(),
+                parseInt(parts[i++].trim()), parseInt(parts[i++].trim()),
+                parseInt(parts[i++].trim()), parts[i++].trim());
     }
 
     @Override
@@ -85,7 +88,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Creates a new Spinnaker Machine
+     * Creates a new Spinnaker Machine.
      *
      * @param machineName
      *            The name of the machine
@@ -102,7 +105,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Gets the name of the machine
+     * Gets the name of the machine.
      *
      * @return The name of the machine
      */
@@ -111,7 +114,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Sets the name of the machine
+     * Sets the name of the machine.
      *
      * @param machineName
      *            The name of the machine
@@ -121,7 +124,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Gets the version of the machine
+     * Gets the version of the machine.
      *
      * @return The version of the machine
      */
@@ -130,7 +133,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Sets the version of the machine
+     * Sets the version of the machine.
      *
      * @param version
      *            The version of the machine
@@ -140,7 +143,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Gets the width of the machine
+     * Gets the width of the machine.
      *
      * @return The width of the machine
      */
@@ -149,7 +152,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Sets the width of the machine
+     * Sets the width of the machine.
      *
      * @param width
      *            The width of the machine
@@ -159,7 +162,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Gets the height of the machine
+     * Gets the height of the machine.
      *
      * @return The height of the machine
      */
@@ -168,7 +171,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Sets the height of the machine
+     * Sets the height of the machine.
      *
      * @param height
      *            The height of the machine
@@ -183,7 +186,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Gets the number of boards in the machine
+     * Gets the number of boards in the machine.
      *
      * @return The number of boards in the machine
      */
@@ -192,7 +195,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Sets the number of boards in the machine
+     * Sets the number of boards in the machine.
      *
      * @param nBoards
      *            The number of boards in the machine
@@ -202,7 +205,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Gets the BMP details of the machine
+     * Gets the BMP details of the machine.
      *
      * @return The BMP details of the machine
      */
@@ -211,7 +214,7 @@ public class SpinnakerMachine
     }
 
     /**
-     * Sets the BMP details of the machine
+     * Sets the BMP details of the machine.
      *
      * @param bmpDetails
      *            The BMP details of the machine

--- a/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/machine/SpinnakerMachine.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/machine/SpinnakerMachine.java
@@ -57,6 +57,11 @@ public class SpinnakerMachine
      *
      * @param value
      *            The name of the machine to parse.
+     * @return The parsed machine descriptor.
+     * @throws IllegalArgumentException
+     *             if the description has the wrong overall format
+     * @throws NumberFormatException
+     *             if one of the parts that should be numeric isn't
      */
     public static SpinnakerMachine parse(final String value) {
         if (!value.startsWith("(") || !value.endsWith(")")) {
@@ -88,19 +93,29 @@ public class SpinnakerMachine
     }
 
     /**
-     * Creates a new Spinnaker Machine.
+     * Creates a new SpiNNaker Machine description.
      *
      * @param machineName
      *            The name of the machine
+     * @param version
+     *            The version of the machine
+     * @param width
+     *            The width of the machine, in boards
+     * @param height
+     *            The width of the machine, in boards
+     * @param numBoards
+     *            The number of boards in the machine
+     * @param bmpDetails
+     *            How to contact the machine's Board Management Processor
      */
     public SpinnakerMachine(final String machineName, final String version,
-            final int width, final int height, final int nBoards,
+            final int width, final int height, final int numBoards,
             final String bmpDetails) {
         this.machineName = machineName;
         this.version = version;
         this.width = width;
         this.height = height;
-        this.nBoards = nBoards;
+        this.nBoards = numBoards;
         this.bmpDetails = bmpDetails;
     }
 

--- a/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/machine/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/machine/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The description of SpiNNaker machines.
+ */
+package uk.ac.manchester.cs.spinnaker.machine;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/JobExecuter.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/JobExecuter.java
@@ -1,14 +1,14 @@
 package uk.ac.manchester.cs.spinnaker.jobmanager;
 
 /**
- * Executes jobs in an external process
+ * Executes jobs in an external process.
  *
  * @see LocalJobExecuterFactory.Executer
  * @see XenVMExecuterFactory.Executer
  */
 public interface JobExecuter {
     /**
-     * Gets the id of the executer
+     * Gets the id of the executer.
      *
      * @return The id
      */

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/JobExecuterFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/JobExecuterFactory.java
@@ -4,14 +4,14 @@ import java.io.IOException;
 import java.net.URL;
 
 /**
- * A factory for creating job executers
+ * A factory for creating job executers.
  *
  * @see LocalJobExecuterFactory
  * @see XenVMExecuterFactory
  */
 public interface JobExecuterFactory {
     /**
-     * Creates a new JobExecuter
+     * Creates a new JobExecuter.
      *
      * @param manager
      *            The manager requesting the creation

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/LocalJobExecuterFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/LocalJobExecuterFactory.java
@@ -129,7 +129,7 @@ public class LocalJobExecuterFactory implements JobExecuterFactory {
         private IOException startException;
 
         /**
-         * Create a JobExecuter
+         * Create a JobExecuter.
          *
          * @param arguments
          *            The arguments to use
@@ -157,7 +157,7 @@ public class LocalJobExecuterFactory implements JobExecuterFactory {
         }
 
         /**
-         * Runs the external job
+         * Runs the external job.
          *
          * @throws IOException
          *             If there is an error starting the job
@@ -262,7 +262,7 @@ public class LocalJobExecuterFactory implements JobExecuterFactory {
         }
 
         /**
-         * Gets the location of the process log file
+         * Gets the location of the process log file.
          *
          * @return The location of the log file
          */

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The job executers and their factories.
+ */
+package uk.ac.manchester.cs.spinnaker.jobmanager;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/FixedMachineManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/FixedMachineManagerImpl.java
@@ -11,11 +11,11 @@ import uk.ac.manchester.cs.spinnaker.machine.ChipCoordinates;
 import uk.ac.manchester.cs.spinnaker.machine.SpinnakerMachine;
 
 /**
- * A manager of SpiNNaker machines
+ * A manager of directly-connected SpiNNaker machines.
  */
 public class FixedMachineManagerImpl implements MachineManager {
     /**
-     * The queue of available machines
+     * The queue of available machines.
      */
     private final Set<SpinnakerMachine> machinesAvailable = new HashSet<>();
     private final Set<SpinnakerMachine> machinesAllocated = new HashSet<>();
@@ -38,7 +38,7 @@ public class FixedMachineManagerImpl implements MachineManager {
     }
 
     /**
-     * Gets the next machine available, or waits if no machine is available
+     * Gets the next machine available, or waits if no machine is available.
      *
      * @param nBoards
      *            The number of boards to request
@@ -77,7 +77,7 @@ public class FixedMachineManagerImpl implements MachineManager {
     }
 
     /**
-     * Releases a machine that was previously in use
+     * Releases a machine that was previously in use.
      *
      * @param machine
      *            The machine to release
@@ -92,7 +92,7 @@ public class FixedMachineManagerImpl implements MachineManager {
     }
 
     /**
-     * Closes the manager
+     * Closes the manager.
      */
     @Override
     public void close() {

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/commands/CreateJobCommand.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/commands/CreateJobCommand.java
@@ -1,9 +1,9 @@
 package uk.ac.manchester.cs.spinnaker.machinemanager.commands;
 
 public class CreateJobCommand extends Command<Integer> {
-    public CreateJobCommand(final int n_boards, final String owner) {
+    public CreateJobCommand(final int numBoards, final String owner) {
         super("create_job");
-        addArg(n_boards);
+        addArg(numBoards);
         addKwArg("owner", owner);
     }
 }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/commands/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/commands/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Commands to send to Spalloc.
+ */
+package uk.ac.manchester.cs.spinnaker.machinemanager.commands;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The description of SpiNNaker jobs.
+ */
+package uk.ac.manchester.cs.spinnaker.machinemanager;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/responses/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/responses/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Responses received from Spalloc.
+ */
+package uk.ac.manchester.cs.spinnaker.machinemanager.responses;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Model bits and pieces.
+ */
+package uk.ac.manchester.cs.spinnaker.model;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/nmpi/NMPIQueueManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/nmpi/NMPIQueueManager.java
@@ -35,7 +35,7 @@ import uk.ac.manchester.cs.spinnaker.rest.utils.CustomJacksonJsonProvider;
 import uk.ac.manchester.cs.spinnaker.rest.utils.PropertyBasedDeserialiser;
 
 /**
- * Manages the NMPI queue, receiving jobs and submitting them to be run
+ * Manages the NMPI queue, receiving jobs and submitting them to be run.
  */
 public class NMPIQueueManager implements Runnable {
 
@@ -64,33 +64,33 @@ public class NMPIQueueManager implements Runnable {
      */
     private static final int EMPTY_QUEUE_SLEEP_MS = 10000;
 
-    /** The queue to get jobs from */
+    /** The queue to get jobs from. */
     private NMPIQueue queue;
-    /** Marker to indicate if the manager is done or not */
+    /** Marker to indicate if the manager is done or not. */
     private boolean done = false;
-    /** The set of listeners for this queue */
+    /** The set of listeners for this queue. */
     private final Set<NMPIQueueListener> listeners = new HashSet<>();
-    /** A cache of jobs that have been received */
+    /** A cache of jobs that have been received. */
     private final Map<Integer, Job> jobCache = new HashMap<>();
-    /** The log of the job so far */
+    /** The log of the job so far. */
     private final Map<Integer, NMPILog> jobLog = new HashMap<>();
     private final Logger logger = getLogger(getClass());
 
-    /** The hardware identifier for the queue */
+    /** The hardware identifier for the queue. */
     @Value("${nmpi.hardware}")
     private String hardware;
-    /** The URL from which to load the data */
+    /** The URL from which to load the data. */
     @Value("${nmpi.url}")
     private URL nmpiUrl;
-    /** The username to log in to the server with */
+    /** The username to log in to the server with. */
     @Value("${nmpi.username}")
     private String nmpiUsername;
-    /** The password or API key to log in to the server with */
+    /** The password or API key to log in to the server with. */
     @Value("${nmpi.password}")
     private String nmpiPassword;
     /**
      * True if the password is an API key, False if the password should be used
-     * to obtain the key
+     * to obtain the key.
      */
     @Value("${nmpi.passwordIsApiKey}")
     private boolean nmpiPasswordIsApiKey;
@@ -102,9 +102,8 @@ public class NMPIQueueManager implements Runnable {
 
         @SuppressWarnings("serial")
         class QueueResponseDeserialiser
-                extends
-                    PropertyBasedDeserialiser<QueueNextResponse> {
-            public QueueResponseDeserialiser() {
+                extends PropertyBasedDeserialiser<QueueNextResponse> {
+            QueueResponseDeserialiser() {
                 super(QueueNextResponse.class);
                 register("id", Job.class);
                 register("warning", QueueEmpty.class);
@@ -125,7 +124,7 @@ public class NMPIQueueManager implements Runnable {
 
     /**
      * Gets a job from the cache, or from the server if the job is not in the
-     * cache
+     * cache.
      *
      * @param id
      *            The id of the job
@@ -143,7 +142,7 @@ public class NMPIQueueManager implements Runnable {
     }
 
     /**
-     * Register a listener against the manager for new jobs
+     * Register a listener against the manager for new jobs.
      *
      * @param listener
      *            The listener to register
@@ -199,7 +198,7 @@ public class NMPIQueueManager implements Runnable {
     }
 
     /**
-     * Appends log messages to the log
+     * Appends log messages to the log.
      *
      * @param id
      *            The id of the job
@@ -226,7 +225,7 @@ public class NMPIQueueManager implements Runnable {
     }
 
     /**
-     * Marks a job as finished successfully
+     * Marks a job as finished successfully.
      *
      * @param id
      *            The id of the job
@@ -261,7 +260,7 @@ public class NMPIQueueManager implements Runnable {
     }
 
     /**
-     * Marks a job as finished with an error
+     * Marks a job as finished with an error.
      *
      * @param id
      *            The id of the job
@@ -306,7 +305,7 @@ public class NMPIQueueManager implements Runnable {
     }
 
     /**
-     * Close the manager
+     * Close the manager.
      */
     public void close() {
         done = true;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/nmpi/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/nmpi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of the HBP NMPI back-end protocol.
+ */
+package uk.ac.manchester.cs.spinnaker.nmpi;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/output/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/output/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Manages output from jobs.
+ */
+package uk.ac.manchester.cs.spinnaker.output;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/remote/web/BearerOidcClient.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/remote/web/BearerOidcClient.java
@@ -167,8 +167,7 @@ public class BearerOidcClient
         private String accessToken;
         private OidcProfile profile;
 
-        public BearerCredentials(final String accessToken,
-                final OidcProfile profile) {
+        BearerCredentials(String accessToken, OidcProfile profile) {
             this.accessToken = accessToken;
             this.profile = profile;
         }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/remote/web/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/remote/web/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The main web interface bits and pieces.
+ */
+package uk.ac.manchester.cs.spinnaker.remote.web;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/UnicoreFileClient.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/UnicoreFileClient.java
@@ -14,7 +14,7 @@ import javax.ws.rs.WebApplicationException;
 @Path("/storages")
 public interface UnicoreFileClient {
     /**
-     * Upload a file
+     * Upload a file.
      *
      * @param id
      *            The id of the storage on the server.
@@ -29,7 +29,7 @@ public interface UnicoreFileClient {
     @PUT
     @Path("{id}/files/{filePath}")
     @Consumes("application/octet-stream")
-    public void upload(@PathParam("id") String id,
+    void upload(@PathParam("id") String id,
             @PathParam("filePath") String filePath, InputStream input)
             throws WebApplicationException;
 }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The REST interface.
+ */
+package uk.ac.manchester.cs.spinnaker.rest;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/ErrorCaptureResponseFilter.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/ErrorCaptureResponseFilter.java
@@ -25,9 +25,9 @@ public class ErrorCaptureResponseFilter implements ClientResponseFilter {
             new CustomJacksonJsonProvider();
     private static final Logger log =
             getLogger(ErrorCaptureResponseFilter.class);
-    public volatile boolean writeToLog = true;
+    private volatile boolean writeToLog = true;
 
-    private static final String INDENT = "    ";// 4 spaces
+    private static final String INDENT = "    "; // 4 spaces
     private static final String IND2 = INDENT + INDENT;
 
     @Override

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/NullExceptionMapper.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/NullExceptionMapper.java
@@ -1,6 +1,7 @@
 package uk.ac.manchester.cs.spinnaker.rest.utils;
 
 import static javax.ws.rs.core.Response.status;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import javax.ws.rs.core.Response;
@@ -16,17 +17,16 @@ import org.slf4j.Logger;
  */
 @Provider
 public class NullExceptionMapper
-        implements
-            ExceptionMapper<NullPointerException> {
+        implements ExceptionMapper<NullPointerException> {
     private final Logger log = getLogger(getClass());
 
     @Override
-    public Response toResponse(final NullPointerException exception) {
+    public Response toResponse(NullPointerException exception) {
         String msg = exception.getMessage();
         if ((msg == null) || msg.isEmpty()) {
             msg = "bad parameter";
         }
         log.info("trapped exception in service method", exception);
-        return status(400).entity(msg).build();
+        return status(BAD_REQUEST).entity(msg).build();
     }
 }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/SpringRestClientUtils.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/SpringRestClientUtils.java
@@ -8,17 +8,16 @@ import java.net.URL;
 import org.pac4j.oidc.profile.OidcProfile;
 import org.pac4j.springframework.security.authentication.ClientAuthenticationToken;
 
-public class SpringRestClientUtils {
-    public static <T> T createOIDCClient(final URL url, final Class<T> clazz) {
+public abstract class SpringRestClientUtils {
+    public static <T> T createOIDCClient(URL url, Class<T> clazz) {
         try {
-            final ClientAuthenticationToken clientAuth =
-                    (ClientAuthenticationToken) getContext()
-                            .getAuthentication();
-            final OidcProfile oidcProfile =
-                    (OidcProfile) clientAuth.getUserProfile();
+            ClientAuthenticationToken clientAuth = (ClientAuthenticationToken)
+                    getContext().getAuthentication();
+            OidcProfile oidcProfile = (OidcProfile)
+                    clientAuth.getUserProfile();
             return createBearerClient(url, oidcProfile.getIdTokenString(),
                     clazz);
-        } catch (final ClassCastException e) {
+        } catch (ClassCastException e) {
             throw new RuntimeException("Current Authentication is not OIDC");
         }
     }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Utilities used to support the REST interface.
+ */
+package uk.ac.manchester.cs.spinnaker.rest.utils;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/utils/ThreadUtils.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/utils/ThreadUtils.java
@@ -8,10 +8,10 @@ public abstract class ThreadUtils {
      * Recommended way of doing "quiet" sleeps.
      *
      * @param delay
-     *          How long to sleep, in milliseconds.
-     * @see <a href=
-     *      "http://stackoverflow.com/questions/1087475/when-does-javas-thread-sleep-throw-interruptedexception"
-     *      >stackoverflow.com/.../when-does-javas-thread-sleep-throw-interruptedexception</a>
+     *            How long to sleep for, in milliseconds.
+     * @see <a href="https://stackoverflow.com/q/1087475/301832">Stack Overflow
+     *      Question: When does Java's Thread.sleep throw
+     *      InterruptedException?</a>
      */
     public static void sleep(final long delay) {
         try {

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/utils/package-info.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/utils/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * General utilites.
+ */
+package uk.ac.manchester.cs.spinnaker.utils;

--- a/RemoteSpiNNaker/src/support/checkstyle/style.xml
+++ b/RemoteSpiNNaker/src/support/checkstyle/style.xml
@@ -22,13 +22,19 @@
 			<property name="validateThrows" value="true" />
 			<property name="allowMissingThrowsTags" value="true" />
 			<property name="allowUndeclaredRTE" value="true" />
+			<!-- TEMPORARY: Make most javadoc errors ignored -->
+	        <property name="severity" value="ignore"/>
 		</module>
 		<module name="JavadocType">
 			<property name="scope" value="package" />
+			<!-- TEMPORARY: Make most javadoc errors ignored -->
+	        <property name="severity" value="ignore"/>
 		</module>
 		<module name="JavadocVariable">
 			<property name="scope" value="package" />
 			<property name="ignoreNamePattern" value="log|logger" />
+			<!-- TEMPORARY: Make most javadoc errors ignored -->
+	        <property name="severity" value="ignore"/>
 		</module>
 		<module name="JavadocStyle" />
 		<module name="ConstantName">


### PR DESCRIPTION
This turns on the style checker and fixes some of the issues it turns off. Many of the javadoc checks are disabled, but the effort to put in doc comments across the whole codebase is significant.

Annoyingly, the style used by checkstyle (even with tuning) is slightly off what Eclipse does by default.

(This recovers some of what was in SpiNNakerManchester/RemoteSpiNNaker#17)