### PR TITLE
Update versions of dependencies

### DIFF
--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/remote/web/DirectClientAuthenticationFilter.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/remote/web/DirectClientAuthenticationFilter.java
@@ -148,7 +148,7 @@ public class DirectClientAuthenticationFilter extends OncePerRequestFilter {
      * @param context The encapsulation of the request and response.
      * @return The credentials, or {@code null} if none suitable are found.
      */
-    private Credentials getCredentials(WebContext context) {
+    private Credentials getCredentials(final WebContext context) {
         try {
             return client.getCredentials(context);
         } catch (final RequiresHttpAction e) {

--- a/RemoteSpiNNaker/pom.xml
+++ b/RemoteSpiNNaker/pom.xml
@@ -8,24 +8,23 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <resteasy.version>3.0.8.Final</resteasy.version>
-        <jackson.version>2.9.1</jackson.version>
-        <httpclient.version>4.2.1</httpclient.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <resteasy.version>3.6.2.Final</resteasy.version>
+        <jackson.version>2.9.8</jackson.version>
         <xen.version>6.2.0-3.1</xen.version>
         <ini4j.version>0.5.4</ini4j.version>
-        <jgit.version>3.5.0.201409071800-rc1</jgit.version>
+        <jgit.version>5.2.1.201812262042-r</jgit.version>
         <jarchivelib.version>0.7.1</jarchivelib.version>
-        <springsecurity.version>4.0.3.RELEASE</springsecurity.version>
-        <spring.version>4.1.0.RELEASE</spring.version>
-        <cxf.version>3.0.1</cxf.version>
-        <slf4j.version>1.7.7</slf4j.version>
-        <pac4j.springsecurity.version>1.4.1</pac4j.springsecurity.version>
-        <pac4j.oidc.version>1.8.5</pac4j.oidc.version>
+        <springsecurity.version>4.2.11.RELEASE</springsecurity.version>
+        <spring.version>4.3.22.RELEASE</spring.version>
+        <cxf.version>3.3.0</cxf.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <pac4j.springsecurity.version>1.4.3</pac4j.springsecurity.version>
+        <pac4j.oidc.version>1.8.9</pac4j.oidc.version>
         <j2ee.version>6.0</j2ee.version>
-        <commons.lang.version>3.4</commons.lang.version>
-        <commons.io.version>2.5</commons.io.version>
+        <commons.lang.version>3.8.1</commons.lang.version>
+        <commons.io.version>2.6</commons.io.version>
     </properties>
 
     <dependencyManagement>
@@ -89,7 +88,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>${httpclient.version}</version>
+                <version>[4.3.6,)</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
@@ -134,7 +133,7 @@
             <dependency>
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
-                <version>2.0</version>
+                <version>2.1.1</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -151,27 +150,27 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.4.1</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.8</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.2.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -185,7 +184,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.0.1</version>
                     <configuration>
                         <quiet>true</quiet>
                     </configuration>
@@ -193,7 +192,7 @@
                 <plugin>
                     <groupId>org.mortbay.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
-                    <version>8.1.15.v20140411</version>
+                    <version>9.4.14.v20181114</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
There were security alerts against some of our dependencies; this brings our dependencies more up to date.

Updating the OIDC version required a little refactoring. (It's _very_ tricky to go further! The library makes assumptions in later versions that we violate.)