### PR TITLE
Split the long build+test from the quicker validate+doc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 name: Build and Test
-
 on: [push]
+env:
+  CI_NAME: "Github Actions"
 
 jobs:
   build:
@@ -23,67 +24,103 @@ jobs:
     strategy:
       matrix:
         java: [8, 11, 14]
-    env:
-      CI_NAME: "Github Actions"
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set dynamic information
-        id: refs
-        env:
-          BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
-        run: |
-          echo "::set-output name=branch_name::${BRANCH_NAME_OR_REF#refs/heads/}"
-          echo "::set-output name=pr_number::$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
-          echo "SETTINGS_FILE=$PWD/.github/settings.xml" >> $GITHUB_ENV
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-j${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2-j${{ matrix.java }}
+    - uses: actions/checkout@v2
+    - name: Set dynamic information
+      id: refs
+      env:
+        BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
+      run: |
+        echo "::set-output name=branch_name::${BRANCH_NAME_OR_REF#refs/heads/}"
+        echo "::set-output name=pr_number::$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
+        echo "SETTINGS_FILE=$PWD/.github/settings.xml" >> $GITHUB_ENV
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: test-m2-j${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: test-m2-j${{ matrix.java }}
+    - name: Maven library-update
+      run: mvn -B dependency:resolve dependency:resolve-plugins --settings $SETTINGS_FILE
+      working-directory: RemoteSpiNNaker
+      continue-on-error: true
 
-      - name: Maven library-update
-        run: mvn -B dependency:resolve dependency:resolve-plugins --settings $SETTINGS_FILE || true
-        working-directory: RemoteSpiNNaker
+    - name: Maven compile
+      run: mvn install --settings $SETTINGS_FILE -DskipTests=true -Dmaven.javadoc.skip=true
+      working-directory: RemoteSpiNNaker
+    - name: Maven test
+      id: test
+      run: mvn verify --settings $SETTINGS_FILE -Dmaven.javadoc.skip=true jacoco:report
+      working-directory: RemoteSpiNNaker
+    - name: "Report Coverage via coveralls.io"
+      run: mvn coveralls:report --settings $SETTINGS_FILE --no-transfer-progress -DrepoToken=$COVERALLS_SECRET
+      working-directory: RemoteSpiNNaker
+      env:
+        CI_BUILD_NUMBER: ${{ github.run_id }}
+        CI_BUILD_URL: https://github.com/${{ github.repository }}/commit/${{ github.event.after }}/checks
+        CI_BRANCH: ${{ steps.refs.outputs.branch_name }}
+        CI_PULL_REQUEST: ${{ steps.refs.outputs.pr_number }}
+        COVERALLS_SECRET: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
-      - name: Maven rat
-        run: mvn apache-rat:check --settings $SETTINGS_FILE -V || (find . -type f -name 'rat*.txt' -print | xargs grep -l unapproved | xargs cat; exit 1)
-        working-directory: RemoteSpiNNaker
+    - name: "Post-Run: Purge SNAPSHOTs"
+      # Do not cache SNAPSHOT dependencies; we don't use external snapshots
+      # and we will always rebuild internal snapshots.
+      run: mvn dependency:purge-local-repository --settings $SETTINGS_FILE -DsnapshotsOnly=true -DreResolve=false
+      working-directory: RemoteSpiNNaker
+      continue-on-error: true
 
-      - name: Maven compile
-        run: mvn install --settings $SETTINGS_FILE -DskipTests=true -Dmaven.javadoc.skip=true
-        working-directory: RemoteSpiNNaker
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8]
 
-      - name: Maven test
-        id: test
-        run: mvn verify --settings $SETTINGS_FILE -Dmaven.javadoc.skip=true jacoco:report
-        working-directory: RemoteSpiNNaker
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set dynamic information
+      id: refs
+      env:
+        BRANCH_NAME_OR_REF: ${{ github.head_ref || github.ref }}
+      run: |
+        echo "::set-output name=branch_name::${BRANCH_NAME_OR_REF#refs/heads/}"
+        echo "::set-output name=pr_number::$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")"
+        echo "SETTINGS_FILE=$PWD/.github/settings.xml" >> $GITHUB_ENV
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: validate-m2-j${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: validate-m2-j${{ matrix.java }}
+    - name: Maven library-update
+      run: mvn -B dependency:resolve dependency:resolve-plugins --settings $SETTINGS_FILE
+      working-directory: RemoteSpiNNaker
+      continue-on-error: true
 
-      - name: Maven checkstyle
-        run: mvn checkstyle:check --settings $SETTINGS_FILE -Dmaven.javadoc.skip=true
-        working-directory: RemoteSpiNNaker
+    - name: Maven rat
+      run: mvn apache-rat:check --settings $SETTINGS_FILE -V || (find . -type f -name 'rat*.txt' -print | xargs grep -l unapproved | xargs cat; exit 1)
+      working-directory: RemoteSpiNNaker
+    - name: Maven compile
+      run: mvn install --settings $SETTINGS_FILE -DskipTests=true -Dmaven.javadoc.skip=true
+      working-directory: RemoteSpiNNaker
+    - name: Maven checkstyle
+      run: mvn checkstyle:check --settings $SETTINGS_FILE -Dmaven.javadoc.skip=true
+      working-directory: RemoteSpiNNaker
+    - name: Maven javadoc
+      run: mvn javadoc:aggregate --settings $SETTINGS_FILE
+      working-directory: RemoteSpiNNaker
 
-      - name: Maven javadoc
-        run: mvn javadoc:aggregate --settings $SETTINGS_FILE
-        working-directory: RemoteSpiNNaker
-
-      - name: "Report Coverage via coveralls.io"
-        run: mvn coveralls:report --settings $SETTINGS_FILE --no-transfer-progress -DrepoToken=$COVERALLS_SECRET
-        working-directory: RemoteSpiNNaker
-        env:
-          CI_BUILD_NUMBER: ${{ github.run_id }}
-          CI_BUILD_URL: https://github.com/${{ github.repository }}/commit/${{ github.event.after }}/checks
-          CI_BRANCH: ${{ steps.refs.outputs.branch_name }}
-          CI_PULL_REQUEST: ${{ steps.refs.outputs.pr_number }}
-          COVERALLS_SECRET: ${{ secrets.COVERALLS_REPO_TOKEN }}
-
-      - name: "Post-Run: Purge SNAPSHOTs"
-        # Do not cache SNAPSHOT dependencies; we don't use external snapshots
-        # and we will always rebuild internal snapshots.
-        run: mvn dependency:purge-local-repository --settings $SETTINGS_FILE -DsnapshotsOnly=true -DreResolve=false
-        working-directory: RemoteSpiNNaker
+    - name: "Post-Run: Purge SNAPSHOTs"
+      # Do not cache SNAPSHOT dependencies; we don't use external snapshots
+      # and we will always rebuild internal snapshots.
+      run: mvn dependency:purge-local-repository --settings $SETTINGS_FILE -DsnapshotsOnly=true -DreResolve=false
+      working-directory: RemoteSpiNNaker
+      continue-on-error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 name: Publish
-
-on: [push]
-#  push:
-#    branches: [ master ]
+on:
+  push:
+    branches: [ master ]
 
 jobs:
   build:
@@ -42,12 +41,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2-j${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2-j${{ matrix.java }}
+          key: publish-m2-j${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: publish-m2-j${{ matrix.java }}
 
       - name: Ensure dependencies are present
-        run: mvn -B dependency:resolve dependency:resolve-plugins --settings $SETTINGS_FILE || true
+        run: mvn -B dependency:resolve dependency:resolve-plugins --settings $SETTINGS_FILE
         working-directory: RemoteSpiNNaker
+        continue-on-error: true
       - name: Build
         run: mvn install --settings $SETTINGS_FILE -DskipTests=true -Dmaven.javadoc.skip=true
         working-directory: RemoteSpiNNaker
@@ -56,16 +56,7 @@ jobs:
           mvn site site:stage --settings $SETTINGS_FILE
           touch $SITE_DIR/.nojekyll
         working-directory: RemoteSpiNNaker
-
-      - name: "TEST DOC BUILD!"
-        if: ${{ github.ref != 'refs/heads/master' }}
-        run: ls -AlRFG
-        working-directory: ${{ env.SITE_DIR }}
-        env:
-          CLICOLOR_FORCE: 1
-          TERM: xterm-color
       - name: Deploy to GitHub Pages
-        if: ${{ github.ref == 'refs/heads/master' }}
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -73,7 +64,8 @@ jobs:
           folder: ${{ env.SITE_DIR }}
 
       - name: "Post: Purge SNAPSHOTs"
-        # Do not cache SNAPSHOT dependencies; we don't use external snapshots and we
-        # will always rebuild internal snapshots.
+        # Do not cache SNAPSHOT dependencies; we don't use external snapshots
+        # and we will always rebuild internal snapshots.
         run: mvn dependency:purge-local-repository --settings $SETTINGS_FILE -DsnapshotsOnly=true -DreResolve=false
         working-directory: RemoteSpiNNaker
+        continue-on-error: true


### PR DESCRIPTION
Mark non-critical steps as able to fail silently (as they're just best-effort)