### PR TITLE
Fix lowercase problem

### DIFF
--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
@@ -54,7 +54,10 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.io.filefilter.AbstractFileFilter;
 import org.apache.commons.io.filefilter.IOFileFilter;
+import org.ini4j.Config;
 import org.ini4j.ConfigParser;
+import org.ini4j.Ini;
+import org.ini4j.Profile.Section;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -225,27 +228,28 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
             final File cfgFile = new File(workingDirectory, "spynnaker.cfg");
 
             // Add the details of the machine
-            final ConfigParser parser = new ConfigParser();
+            Ini ini = new Ini();
             if (cfgFile.exists()) {
-                parser.read(cfgFile);
+                ini.load(cfgFile);
             }
 
-            if (!parser.hasSection(SECTION)) {
-                parser.addSection(SECTION);
+            Section section = null;
+            if (!ini.containsKey(SECTION)) {
+                section = ini.add(SECTION);
+            } else {
+                section = ini.get(SECTION);
             }
             if (machine != null) {
-                parser.set(SECTION, "machineName", machine.getMachineName());
-                parser.set(SECTION, "version", machine.getVersion());
-                parser.set(SECTION, "width", machine.getWidth());
-                parser.set(SECTION, "height", machine.getHeight());
+                section.put("machine_name", machine.getMachineName());
+                section.put("version", machine.getVersion());
                 final String bmpDetails = machine.getBmpDetails();
                 if (bmpDetails != null) {
-                    parser.set(SECTION, "bmp_names", bmpDetails);
+                    section.put("bmp_names", bmpDetails);
                 }
             } else {
-                parser.set(SECTION, "remote_spinnaker_url", machineUrl);
+                section.put("remote_spinnaker_url", machineUrl);
             }
-            parser.write(cfgFile);
+            ini.store(cfgFile);
 
             // Keep existing files to compare to later
             final Set<File> existingFiles = gatherFiles(workingDirectory);

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
@@ -54,6 +54,7 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.io.filefilter.AbstractFileFilter;
 import org.apache.commons.io.filefilter.IOFileFilter;
+import org.ini4j.Config;
 import org.ini4j.Ini;
 import org.ini4j.Profile.Section;
 
@@ -227,6 +228,10 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
 
             // Add the details of the machine
             final Ini ini = new Ini();
+            final Config config = ini.getConfig();
+            config.setEscape(false);
+            config.setLowerCaseSection(false);
+            config.setLowerCaseOption(false);
             if (cfgFile.exists()) {
                 ini.load(cfgFile);
             }
@@ -245,7 +250,6 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
                     section.put("bmp_names", bmpDetails);
                 }
             } else {
-                System.err.println("Using Remote URL: " + machineUrl);
                 section.put("remote_spinnaker_url", machineUrl);
             }
             ini.store(cfgFile);

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
@@ -226,12 +226,12 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
             final File cfgFile = new File(workingDirectory, "spynnaker.cfg");
 
             // Add the details of the machine
-            Ini ini = new Ini();
+            final Ini ini = new Ini();
             if (cfgFile.exists()) {
                 ini.load(cfgFile);
             }
 
-            Section section = null;
+            final Section section;
             if (!ini.containsKey(SECTION)) {
                 section = ini.add(SECTION);
             } else {

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
@@ -245,6 +245,7 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
                     section.put("bmp_names", bmpDetails);
                 }
             } else {
+                System.err.println("Using Remote URL: " + machineUrl);
                 section.put("remote_spinnaker_url", machineUrl);
             }
             ini.store(cfgFile);

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
@@ -54,8 +54,6 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.io.filefilter.AbstractFileFilter;
 import org.apache.commons.io.filefilter.IOFileFilter;
-import org.ini4j.Config;
-import org.ini4j.ConfigParser;
 import org.ini4j.Ini;
 import org.ini4j.Profile.Section;
 

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/JobManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/JobManager.java
@@ -213,6 +213,7 @@ public class JobManager implements NMPIQueueListener, JobManagerInterface {
      */
     public JobManager(final URL baseUrlParam) {
         this.baseUrl = requireNonNull(baseUrlParam);
+        System.err.println("Base URL is " + baseUrlParam);
     }
 
     /**


### PR DESCRIPTION
Replace the config file writing with something more low-level to ensure it doesn't change the case of sections and options.

This was tested in operation on the test service.