### PR TITLE
Icinga support

### DIFF
--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/JobManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/JobManager.java
@@ -105,7 +105,7 @@ public class JobManager implements NMPIQueueListener, JobManagerInterface {
     /**
      * Seconds between status updates.
      */
-    private static final int STATUS_UPDATE_PERIOD = 10;
+    public static final int STATUS_UPDATE_PERIOD = 10;
 
     /**
      * The name of the JAR containing the job process manager implementation.

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/Icinga2CheckResult.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/Icinga2CheckResult.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.cs.spinnaker.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/Icinga2CheckResult.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/Icinga2CheckResult.java
@@ -69,13 +69,15 @@ public class Icinga2CheckResult {
      * @param host The host to report on.
      * @param service The service to report on.
      */
-    public Icinga2CheckResult(int exitStatus, String pluginOutput, String performanceData,
-            Integer ttl, String host, String service) {
-        this.exitStatus = exitStatus;
-        this.pluginOutput = pluginOutput;
-        this.performanceData = performanceData;
-        this.ttl = ttl;
-        this.host = host;
-        this.service = service;
+    public Icinga2CheckResult(final int exitStatusParam,
+            final String pluginOutputParam, final String performanceDataParam,
+            final Integer ttlParam, final String hostParam,
+            final String serviceParam) {
+        exitStatus = exitStatusParam;
+        pluginOutput = pluginOutputParam;
+        performanceData = performanceDataParam;
+        ttl = ttlParam;
+        host = hostParam;
+        service = serviceParam;
     }
 }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/Icinga2CheckResult.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/Icinga2CheckResult.java
@@ -1,0 +1,51 @@
+package uk.ac.manchester.cs.spinnaker.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Icinga2CheckResult {
+
+    /**
+     * The exit status of the service or host.
+     * For services, 0=OK, 1=WARNING, 2=CRITICAL, 3=UNKNOWN.
+     * For hosts, 0=OK, 1=CRITICAL
+     */
+    @JsonProperty("exit_status")
+    private int exitStatus;
+
+    /**
+     * An output string to report.
+     */
+    @JsonProperty("plugin_output")
+    private String pluginOutput;
+
+    /**
+     * Optional performance data to report.
+     */
+    @JsonProperty("performance_data")
+    private String performanceData;
+
+    /**
+     * Optional durations in seconds of the test result.
+     */
+    private Integer ttl;
+
+    /**
+     * The target host being reported on.
+     */
+    private String host;
+
+    /**
+     * Optional target service being reported on.
+     */
+    private String service;
+
+    public Icinga2CheckResult(int exitStatus, String pluginOutput, String performanceData,
+            Integer ttl, String host, String service) {
+        this.exitStatus = exitStatus;
+        this.pluginOutput = pluginOutput;
+        this.performanceData = performanceData;
+        this.ttl = ttl;
+        this.host = host;
+        this.service = service;
+    }
+}

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/Icinga2CheckResult.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/Icinga2CheckResult.java
@@ -16,12 +16,15 @@
  */
 package uk.ac.manchester.cs.spinnaker.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * A result to report to Icinga.
  *
  */
+@JsonInclude(Include.NON_NULL)
 public class Icinga2CheckResult {
 
     /**
@@ -47,16 +50,19 @@ public class Icinga2CheckResult {
     /**
      * Optional durations in seconds of the test result.
      */
+    @JsonProperty("ttl")
     private Integer ttl;
 
     /**
      * The target host being reported on.
      */
+    @JsonProperty("host")
     private String host;
 
     /**
      * Optional target service being reported on.
      */
+    @JsonProperty("service")
     private String service;
 
     /**

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/Icinga2CheckResult.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/Icinga2CheckResult.java
@@ -18,6 +18,10 @@ package uk.ac.manchester.cs.spinnaker.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * A result to report to Icinga.
+ *
+ */
 public class Icinga2CheckResult {
 
     /**
@@ -55,6 +59,16 @@ public class Icinga2CheckResult {
      */
     private String service;
 
+    /**
+     * Create a new result to report.
+     *
+     * @param exitStatus The status to report.
+     * @param pluginOutput An output string to add to the report.
+     * @param performanceData Any performance data to report as a string.
+     * @param ttl The time at which the next report is expected in seconds.
+     * @param host The host to report on.
+     * @param service The service to report on.
+     */
     public Icinga2CheckResult(int exitStatus, String pluginOutput, String performanceData,
             Integer ttl, String host, String service) {
         this.exitStatus = exitStatus;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/Icinga2CheckResult.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/Icinga2CheckResult.java
@@ -62,12 +62,12 @@ public class Icinga2CheckResult {
     /**
      * Create a new result to report.
      *
-     * @param exitStatus The status to report.
-     * @param pluginOutput An output string to add to the report.
-     * @param performanceData Any performance data to report as a string.
-     * @param ttl The time at which the next report is expected in seconds.
-     * @param host The host to report on.
-     * @param service The service to report on.
+     * @param exitStatusParam The status to report.
+     * @param pluginOutputParam An output string to add to the report.
+     * @param performanceDataParam Any performance data to report as a string.
+     * @param ttlParam The time at which the next report is expected in seconds.
+     * @param hostParam The host to report on.
+     * @param serviceParam The service to report on.
      */
     public Icinga2CheckResult(final int exitStatusParam,
             final String pluginOutputParam, final String performanceDataParam,

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/remote/web/RemoteSpinnakerBeans.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/remote/web/RemoteSpinnakerBeans.java
@@ -56,6 +56,7 @@ import uk.ac.manchester.cs.spinnaker.nmpi.NMPIQueueManager;
 import uk.ac.manchester.cs.spinnaker.output.OutputManagerImpl;
 import uk.ac.manchester.cs.spinnaker.rest.OutputManager;
 import uk.ac.manchester.cs.spinnaker.rest.utils.NullExceptionMapper;
+import uk.ac.manchester.cs.spinnaker.status.Icinga2StatusMonitorManager;
 import uk.ac.manchester.cs.spinnaker.status.NullStatusMonitorManagerImpl;
 import uk.ac.manchester.cs.spinnaker.status.StatusCakeStatusMonitorManagerImpl;
 import uk.ac.manchester.cs.spinnaker.status.StatusMonitorManager;
@@ -68,6 +69,21 @@ import uk.ac.manchester.cs.spinnaker.status.StatusMonitorManager;
 // @EnableWebSecurity
 @Import(JaxRsConfig.class)
 public class RemoteSpinnakerBeans {
+
+    /**
+     * Types of status possible.
+     */
+    public enum StatusServiceType {
+        /**
+         * Status Cake service.
+         */
+        STATUS_CAKE,
+        /**
+         * Icigna2 service.
+         */
+        ICINGA2
+    }
+
     /**
      * Configures using properties.
      *
@@ -145,6 +161,12 @@ public class RemoteSpinnakerBeans {
      */
     @Value("${status.update}")
     private boolean updateStatus;
+
+    /**
+     * The type of status service to use.
+     */
+    @Value("${status.update.type}")
+    private StatusServiceType statusType;
 
     /**
      * Configuration that connects to external HBP services.
@@ -367,7 +389,14 @@ public class RemoteSpinnakerBeans {
     @Bean
     public StatusMonitorManager statusMonitorManager() {
         if (updateStatus) {
-            return new StatusCakeStatusMonitorManagerImpl();
+            if (statusType == StatusServiceType.STATUS_CAKE) {
+                return new StatusCakeStatusMonitorManagerImpl();
+            } else if (statusType == StatusServiceType.ICINGA2) {
+                return new Icinga2StatusMonitorManager();
+            } else {
+                throw new RuntimeException(
+                        "Unknown status service type: " + statusType);
+            }
         }
         return new NullStatusMonitorManagerImpl();
     }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/remote/web/RemoteSpinnakerBeans.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/remote/web/RemoteSpinnakerBeans.java
@@ -56,7 +56,7 @@ import uk.ac.manchester.cs.spinnaker.nmpi.NMPIQueueManager;
 import uk.ac.manchester.cs.spinnaker.output.OutputManagerImpl;
 import uk.ac.manchester.cs.spinnaker.rest.OutputManager;
 import uk.ac.manchester.cs.spinnaker.rest.utils.NullExceptionMapper;
-import uk.ac.manchester.cs.spinnaker.status.Icinga2StatusMonitorManager;
+import uk.ac.manchester.cs.spinnaker.status.Icinga2StatusMonitorManagerImpl;
 import uk.ac.manchester.cs.spinnaker.status.NullStatusMonitorManagerImpl;
 import uk.ac.manchester.cs.spinnaker.status.StatusCakeStatusMonitorManagerImpl;
 import uk.ac.manchester.cs.spinnaker.status.StatusMonitorManager;
@@ -392,7 +392,7 @@ public class RemoteSpinnakerBeans {
             if (statusType == StatusServiceType.STATUS_CAKE) {
                 return new StatusCakeStatusMonitorManagerImpl();
             } else if (statusType == StatusServiceType.ICINGA2) {
-                return new Icinga2StatusMonitorManager();
+                return new Icinga2StatusMonitorManagerImpl();
             } else {
                 throw new RuntimeException(
                         "Unknown status service type: " + statusType);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
@@ -32,6 +32,7 @@ public interface Icinga2 {
      * Update the status of a service or host.
      *
      * @param result The result of a status check to update with.
+     * @return The response from the server as a String.
      */
     @Produces("application/json")
     @Consumes("application/json")

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.cs.spinnaker.rest;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
 import java.util.Map;
 
 import javax.ws.rs.Consumes;
@@ -36,8 +38,8 @@ public interface Icinga2 {
      * @param result The result of a status check to update with.
      * @return The response from the server as a String.
      */
-    @Produces("application/json")
-    @Consumes("application/json")
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
     @POST
     @Path("/v1/actions/process-check-result")
     Map<String, Object> processCheckResult(Icinga2CheckResult result);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
@@ -23,8 +23,16 @@ import javax.ws.rs.Produces;
 
 import uk.ac.manchester.cs.spinnaker.model.Icinga2CheckResult;
 
+/**
+ * Interface to the Icinga2 API for status monitoring.
+ */
 public interface Icinga2 {
 
+    /**
+     * Update the status of a service or host.
+     *
+     * @param result The result of a status check to update with.
+     */
     @Produces("application/json")
     @Consumes("application/json")
     @POST

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.cs.spinnaker.rest;
 
 import javax.ws.rs.Consumes;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
@@ -37,5 +37,5 @@ public interface Icinga2 {
     @Consumes("application/json")
     @POST
     @Path("/v1/actions/process-check-result")
-    void processCheckResult(Icinga2CheckResult result);
+    String processCheckResult(Icinga2CheckResult result);
 }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.cs.spinnaker.rest;
 
+import java.util.Map;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -38,5 +40,5 @@ public interface Icinga2 {
     @Consumes("application/json")
     @POST
     @Path("/v1/actions/process-check-result")
-    String processCheckResult(Icinga2CheckResult result);
+    Map<String, Object> processCheckResult(Icinga2CheckResult result);
 }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/Icinga2.java
@@ -1,0 +1,17 @@
+package uk.ac.manchester.cs.spinnaker.rest;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+import uk.ac.manchester.cs.spinnaker.model.Icinga2CheckResult;
+
+public interface Icinga2 {
+
+    @Produces("application/json")
+    @Consumes("application/json")
+    @POST
+    @Path("/v1/actions/process-check-result")
+    void processCheckResult(Icinga2CheckResult result);
+}

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/RestClientUtils.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/RestClientUtils.java
@@ -103,7 +103,7 @@ public abstract class RestClientUtils {
     }
 
     /**
-     * Create an SSL context with appropriate key store and management
+     * Create an SSL context with appropriate key store and management.
      *
      * @return The created context
      * @throws NoSuchAlgorithmException If the key store can't be read

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManager.java
@@ -1,0 +1,70 @@
+package uk.ac.manchester.cs.spinnaker.status;
+
+import static uk.ac.manchester.cs.spinnaker.rest.utils.RestClientUtils.createBasicClient;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+
+import uk.ac.manchester.cs.spinnaker.jobmanager.JobManager;
+import uk.ac.manchester.cs.spinnaker.model.Icinga2CheckResult;
+import uk.ac.manchester.cs.spinnaker.rest.Icinga2;
+
+public class Icinga2StatusMonitorManager implements StatusMonitorManager {
+
+    private static final long TIMEOUT = 60;
+
+    private static final int STATUS = 0;
+
+    private static final String STATUS_MESSAGE = "OK";
+
+    private static final int STATUS_UPDATE_TTL_MULTIPLIER = 2;
+
+    private Icinga2 icinga;
+
+    @Value("icinga2.url")
+    private String icingaUrl;
+
+    @Value("icinga2.host")
+    private String host;
+
+    @Value("icinca2.service")
+    private String service;
+
+    @Value("icinga2.username")
+    private String username;
+
+    @Value("icinga2.password")
+    private String password;
+
+    /**
+     * Initialise the service.
+     * @throws MalformedURLException if the URL isn't a URL
+     */
+    @PostConstruct
+    private void init() throws MalformedURLException {
+        final ResteasyClient client = new ResteasyClientBuilder().
+                connectTimeout(TIMEOUT, TimeUnit.SECONDS).
+                readTimeout(TIMEOUT, TimeUnit.SECONDS).build();
+        icinga = createBasicClient(new URL(icingaUrl), username, password, Icinga2.class);
+        icinga = client.target(icingaUrl).proxy(Icinga2.class);
+    }
+
+
+    @Override
+    public void updateStatus(int runningJobs, int nBoardsInUse) {
+        String performanceData = runningJobs + " running jobs\n"
+                + nBoardsInUse + " boards in use";
+        int ttl = JobManager.STATUS_UPDATE_PERIOD * STATUS_UPDATE_TTL_MULTIPLIER;
+        Icinga2CheckResult result = new Icinga2CheckResult(
+                STATUS, STATUS_MESSAGE, performanceData, ttl, host, service);
+        icinga.processCheckResult(result);
+    }
+
+}

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManager.java
@@ -18,7 +18,6 @@ package uk.ac.manchester.cs.spinnaker.status;
 
 import static uk.ac.manchester.cs.spinnaker.rest.utils.RestClientUtils.createBasicClient;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManager.java
@@ -67,7 +67,7 @@ public class Icinga2StatusMonitorManager implements StatusMonitorManager {
      * The URL of the service.
      */
     @Value("${icinga2.url}")
-    private String icingaUrl;
+    private URL icingaUrl;
 
     /**
      * The host to report on.
@@ -98,22 +98,22 @@ public class Icinga2StatusMonitorManager implements StatusMonitorManager {
      * @throws MalformedURLException if the URL isn't a URL
      */
     @PostConstruct
-    private void init() throws MalformedURLException {
+    private void init() {
         final ResteasyClient client = new ResteasyClientBuilder().
                 connectTimeout(TIMEOUT, TimeUnit.SECONDS).
                 readTimeout(TIMEOUT, TimeUnit.SECONDS).build();
-        icinga = createBasicClient(new URL(icingaUrl), username, password,
+        icinga = createBasicClient(icingaUrl, username, password,
                 Icinga2.class);
-        icinga = client.target(icingaUrl).proxy(Icinga2.class);
+        icinga = client.target(icingaUrl.toString()).proxy(Icinga2.class);
     }
 
     @Override
-    public void updateStatus(int runningJobs, int nBoardsInUse) {
-        String performanceData = runningJobs + " running jobs\n"
+    public void updateStatus(final int runningJobs, final int nBoardsInUse) {
+        final String performanceData = runningJobs + " running jobs\n"
                 + nBoardsInUse + " boards in use";
-        int ttl = JobManager.STATUS_UPDATE_PERIOD *
-                STATUS_UPDATE_TTL_MULTIPLIER;
-        Icinga2CheckResult result = new Icinga2CheckResult(
+        final int ttl = JobManager.STATUS_UPDATE_PERIOD
+                * STATUS_UPDATE_TTL_MULTIPLIER;
+        final Icinga2CheckResult result = new Icinga2CheckResult(
                 STATUS, STATUS_MESSAGE, performanceData, ttl, host, service);
         icinga.processCheckResult(result);
     }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManager.java
@@ -32,30 +32,64 @@ import uk.ac.manchester.cs.spinnaker.jobmanager.JobManager;
 import uk.ac.manchester.cs.spinnaker.model.Icinga2CheckResult;
 import uk.ac.manchester.cs.spinnaker.rest.Icinga2;
 
+/**
+ * Status monitor manager that reports to Icinga.
+ *
+ */
 public class Icinga2StatusMonitorManager implements StatusMonitorManager {
 
+    /**
+     * Timeout of the socket to talk to the service.
+     */
     private static final long TIMEOUT = 60;
 
+    /**
+     * The status to report - always 0 if reporting as OK.
+     */
     private static final int STATUS = 0;
 
+    /**
+     * The status message to report.
+     */
     private static final String STATUS_MESSAGE = "OK";
 
+    /**
+     * The multiplier for the TTL vs. the status update time.
+     */
     private static final int STATUS_UPDATE_TTL_MULTIPLIER = 2;
 
+    /**
+     * The proxy to speak to the service with.
+     */
     private Icinga2 icinga;
 
+    /**
+     * The URL of the service.
+     */
     @Value("${icinga2.url}")
     private String icingaUrl;
 
+    /**
+     * The host to report on.
+     */
     @Value("${icinga2.host:@null}")
     private String host;
 
+    /**
+     * The service to report on.
+     */
     @Value("${icinca2.service:@null}")
     private String service;
 
+    /**
+     * The username to log in with.
+     */
     @Value("${icinga2.username}")
     private String username;
 
+    /**
+     * The password to log in with.
+     */
     @Value("${icinga2.password}")
     private String password;
 
@@ -68,19 +102,19 @@ public class Icinga2StatusMonitorManager implements StatusMonitorManager {
         final ResteasyClient client = new ResteasyClientBuilder().
                 connectTimeout(TIMEOUT, TimeUnit.SECONDS).
                 readTimeout(TIMEOUT, TimeUnit.SECONDS).build();
-        icinga = createBasicClient(new URL(icingaUrl), username, password, Icinga2.class);
+        icinga = createBasicClient(new URL(icingaUrl), username, password,
+                Icinga2.class);
         icinga = client.target(icingaUrl).proxy(Icinga2.class);
     }
-
 
     @Override
     public void updateStatus(int runningJobs, int nBoardsInUse) {
         String performanceData = runningJobs + " running jobs\n"
                 + nBoardsInUse + " boards in use";
-        int ttl = JobManager.STATUS_UPDATE_PERIOD * STATUS_UPDATE_TTL_MULTIPLIER;
+        int ttl = JobManager.STATUS_UPDATE_PERIOD *
+                STATUS_UPDATE_TTL_MULTIPLIER;
         Icinga2CheckResult result = new Icinga2CheckResult(
                 STATUS, STATUS_MESSAGE, performanceData, ttl, host, service);
         icinga.processCheckResult(result);
     }
-
 }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2020 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package uk.ac.manchester.cs.spinnaker.status;
 
 import static uk.ac.manchester.cs.spinnaker.rest.utils.RestClientUtils.createBasicClient;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManager.java
@@ -44,19 +44,19 @@ public class Icinga2StatusMonitorManager implements StatusMonitorManager {
 
     private Icinga2 icinga;
 
-    @Value("icinga2.url")
+    @Value("${icinga2.url}")
     private String icingaUrl;
 
-    @Value("icinga2.host")
+    @Value("${icinga2.host:@null}")
     private String host;
 
-    @Value("icinca2.service")
+    @Value("${icinca2.service:@null}")
     private String service;
 
-    @Value("icinga2.username")
+    @Value("${icinga2.username}")
     private String username;
 
-    @Value("icinga2.password")
+    @Value("${icinga2.password}")
     private String password;
 
     /**

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.cs.spinnaker.status;
 
+import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.cs.spinnaker.rest.utils.RestClientUtils.createBasicClient;
 
 import java.net.URL;
@@ -25,6 +26,7 @@ import javax.annotation.PostConstruct;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 
 import uk.ac.manchester.cs.spinnaker.jobmanager.JobManager;
@@ -93,6 +95,11 @@ public class Icinga2StatusMonitorManagerImpl implements StatusMonitorManager {
     private String password;
 
     /**
+     * Logging.
+     */
+    private final Logger logger = getLogger(getClass());
+
+    /**
      * Initialise the service.
      * @throws MalformedURLException if the URL isn't a URL
      */
@@ -114,6 +121,11 @@ public class Icinga2StatusMonitorManagerImpl implements StatusMonitorManager {
                 * STATUS_UPDATE_TTL_MULTIPLIER;
         final Icinga2CheckResult result = new Icinga2CheckResult(
                 STATUS, STATUS_MESSAGE, performanceData, ttl, host, service);
-        icinga.processCheckResult(result);
+        try {
+            String response = icinga.processCheckResult(result);
+            logger.info("Status updated, result = " + response);
+        } catch (Throwable e) {
+            logger.error("Error updating to Icinga", e);
+        }
     }
 }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
@@ -21,12 +21,9 @@ import static uk.ac.manchester.cs.spinnaker.rest.utils.RestClientUtils.createBas
 
 import java.net.URL;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
 
-import org.jboss.resteasy.client.jaxrs.ResteasyClient;
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -39,11 +36,6 @@ import uk.ac.manchester.cs.spinnaker.rest.Icinga2;
  *
  */
 public class Icinga2StatusMonitorManagerImpl implements StatusMonitorManager {
-
-    /**
-     * Timeout of the socket to talk to the service.
-     */
-    private static final long TIMEOUT = 60;
 
     /**
      * The status to report - always 0 if reporting as OK.
@@ -106,12 +98,8 @@ public class Icinga2StatusMonitorManagerImpl implements StatusMonitorManager {
      */
     @PostConstruct
     private void init() {
-        final ResteasyClient client = new ResteasyClientBuilder().
-                connectTimeout(TIMEOUT, TimeUnit.SECONDS).
-                readTimeout(TIMEOUT, TimeUnit.SECONDS).build();
         icinga = createBasicClient(icingaUrl, username, password,
                 Icinga2.class);
-        icinga = client.target(icingaUrl.toString()).proxy(Icinga2.class);
     }
 
     @Override

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
@@ -20,6 +20,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.cs.spinnaker.rest.utils.RestClientUtils.createBasicClient;
 
 import java.net.URL;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
@@ -122,7 +123,7 @@ public class Icinga2StatusMonitorManagerImpl implements StatusMonitorManager {
         final Icinga2CheckResult result = new Icinga2CheckResult(
                 STATUS, STATUS_MESSAGE, performanceData, ttl, host, service);
         try {
-            String response = icinga.processCheckResult(result);
+            Map<String, Object> response = icinga.processCheckResult(result);
             logger.info("Status updated, result = " + response);
         } catch (Throwable e) {
             logger.error("Error updating to Icinga", e);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
@@ -106,8 +106,8 @@ public class Icinga2StatusMonitorManagerImpl implements StatusMonitorManager {
 
     @Override
     public void updateStatus(final int runningJobs, final int nBoardsInUse) {
-        final String performanceData = runningJobs + " running jobs\n"
-                + nBoardsInUse + " boards in use";
+        final String performanceData = "'Running Jobs'=" + runningJobs +
+                " 'Boards In Use='" + nBoardsInUse;
         final int ttl = JobManager.STATUS_UPDATE_PERIOD
                 * STATUS_UPDATE_TTL_MULTIPLIER;
         final Icinga2CheckResult result = new Icinga2CheckResult(

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
@@ -35,7 +35,7 @@ import uk.ac.manchester.cs.spinnaker.rest.Icinga2;
  * Status monitor manager that reports to Icinga.
  *
  */
-public class Icinga2StatusMonitorManager implements StatusMonitorManager {
+public class Icinga2StatusMonitorManagerImpl implements StatusMonitorManager {
 
     /**
      * Timeout of the socket to talk to the service.

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
@@ -106,8 +106,8 @@ public class Icinga2StatusMonitorManagerImpl implements StatusMonitorManager {
 
     @Override
     public void updateStatus(final int runningJobs, final int nBoardsInUse) {
-        final String performanceData = "'Running Jobs'=" + runningJobs +
-                " 'Boards In Use'=" + nBoardsInUse;
+        final String performanceData = "'Running Jobs'=" + runningJobs
+                + " 'Boards In Use'=" + nBoardsInUse;
         final int ttl = JobManager.STATUS_UPDATE_PERIOD
                 * STATUS_UPDATE_TTL_MULTIPLIER;
         final Icinga2CheckResult result = new Icinga2CheckResult(

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/status/Icinga2StatusMonitorManagerImpl.java
@@ -107,7 +107,7 @@ public class Icinga2StatusMonitorManagerImpl implements StatusMonitorManager {
     @Override
     public void updateStatus(final int runningJobs, final int nBoardsInUse) {
         final String performanceData = "'Running Jobs'=" + runningJobs +
-                " 'Boards In Use='" + nBoardsInUse;
+                " 'Boards In Use'=" + nBoardsInUse;
         final int ttl = JobManager.STATUS_UPDATE_PERIOD
                 * STATUS_UPDATE_TTL_MULTIPLIER;
         final Icinga2CheckResult result = new Icinga2CheckResult(

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/resources/log4j.properties
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/resources/log4j.properties
@@ -22,6 +22,8 @@ log4j.appender.console.Target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 
+#log4j.logger.uk.ac.manchester.cs.spinnaker.rest.utils.ErrorCaptureResponseFilter=TRACE, console
+#log4j.additivity.uk.ac.manchester.cs.spinnaker.rest.utils.ErrorCaptureResponseFilter=false
 #log4j.logger.uk.ac.manchester.cs.spinnaker.jobmanager.JobManager=TRACE, console
 #log4j.additivity.uk.ac.manchester.cs.spinnaker.jobmanager.JobManager=false
 #log4j.logger.uk.ac.manchester.cs.spinnaker.machinemanager=TRACE, console


### PR DESCRIPTION
Add support for Icinga, which is used by EBRAINS.  This has been tested and appears to work correctly.  Currently this expects only one status reporting to happen; it might be that we need to extend that, at least during transition between the two.