### PR TITLE
Timeout spalloc

### DIFF
--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/SpallocMachineManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/SpallocMachineManagerImpl.java
@@ -518,7 +518,8 @@ public class SpallocMachineManagerImpl implements MachineManager, Runnable {
                         writeRequest(request);
                         return getNextResponse(responseType);
                     } catch (IOException e) {
-                        connected = false;
+                        // Disconnect on an error to force reconnection
+                        disconnect();
                         lastError = e;
                     }
                 }


### PR DESCRIPTION
Avoids issues if spalloc stops responding for any reason.  This should enforce a reconnection of spalloc in these cases.