### PR TITLE
Put version info in root POM

### DIFF
--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/pom.xml
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/pom.xml
@@ -70,9 +70,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>RemoteSpiNNakerModel</artifactId>
-			<version>${project.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.ini4j</groupId>
 			<artifactId>ini4j</artifactId>
@@ -106,7 +104,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.15</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/pom.xml
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/pom.xml
@@ -97,11 +97,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>RemoteSpiNNakerModel</artifactId>
-            <version>${project.version}</version>
         </dependency>
-        <!-- <dependency> <groupId>${project.groupId}</groupId> <artifactId>RemoteSpiNNakerJobProcessModel</artifactId>
-            <version>${project.version}</version> <scope>provided</scope> </dependency> -->
-
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
@@ -178,19 +174,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.nimbusds</groupId>
-                <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.21</version>
-            </dependency>
-            <dependency>
-                <groupId>net.minidev</groupId>
-                <artifactId>json-smart</artifactId>
-                <version>2.4.8</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 </project>

--- a/RemoteSpiNNaker/pom.xml
+++ b/RemoteSpiNNaker/pom.xml
@@ -31,35 +31,31 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <resteasy.version>6.0.0.Final</resteasy.version>
         <jackson.version>2.13.2</jackson.version>
-        <httpclient.version>4.5.13</httpclient.version>
-        <xen.version>6.2.0-3.1</xen.version>
-        <ini4j.version>0.5.4</ini4j.version>
-        <jgit.version>5.13.0.202109080827-r</jgit.version>
-        <jarchivelib.version>1.2.0</jarchivelib.version>
         <springsecurity.version>5.6.2</springsecurity.version>
         <spring.version>5.3.16</spring.version>
-        <cxf.version>3.5.1</cxf.version>
         <slf4j.version>1.7.36</slf4j.version>
         <pac4j.springsecurity.version>1.4.3</pac4j.springsecurity.version>
         <pac4j.oidc.version>1.8.9</pac4j.oidc.version>
-        <j2ee.version>8.0.1</j2ee.version>
-        <commons.lang.version>3.12.0</commons.lang.version>
-        <commons.io.version>2.11.0</commons.io.version>
-		<jacoco.version>0.8.7</jacoco.version>
         <javadoc.version>3.3.2</javadoc.version>
+        <jaxb.version>2.3.1</jaxb.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+	        <dependency>
+	            <groupId>${project.groupId}</groupId>
+	            <artifactId>RemoteSpiNNakerModel</artifactId>
+	            <version>${project.version}</version>
+	        </dependency>
             <dependency>
                 <groupId>org.ini4j</groupId>
                 <artifactId>ini4j</artifactId>
-                <version>${ini4j.version}</version>
+                <version>0.5.4</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jgit</groupId>
                 <artifactId>org.eclipse.jgit</artifactId>
-                <version>${jgit.version}</version>
+                <version>5.13.0.202109080827-r</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.httpcomponents</groupId>
@@ -70,23 +66,28 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <dependency>
                 <groupId>org.rauschig</groupId>
                 <artifactId>jarchivelib</artifactId>
-                <version>${jarchivelib.version}</version>
+                <version>1.2.0</version>
             </dependency>
             <dependency>
                 <groupId>net.java.dev.vcc.thirdparty</groupId>
                 <artifactId>xen-api</artifactId>
-                <version>${xen.version}</version>
+                <version>6.2.0-3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>${commons.lang.version}</version>
+                <version>3.12.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>${commons.io.version}</version>
+                <version>2.11.0</version>
             </dependency>
+			<dependency>
+				<groupId>commons-codec</groupId>
+				<artifactId>commons-codec</artifactId>
+				<version>1.15</version>
+			</dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-core-spi</artifactId>
@@ -115,12 +116,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>${httpclient.version}</version>
+                <version>4.5.13</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-                <version>${cxf.version}</version>
+                <version>3.5.1</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
@@ -165,7 +166,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <dependency>
                 <groupId>javax</groupId>
                 <artifactId>javaee-api</artifactId>
-                <version>${j2ee.version}</version>
+                <version>8.0.1</version>
             </dependency>
             <dependency>
                 <groupId>javax.ws.rs</groupId>
@@ -182,6 +183,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<groupId>jakarta.xml.bind</groupId>
 				<artifactId>jakarta.xml.bind-api</artifactId>
 				<version>3.0.1</version>
+			</dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>9.21</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.4.8</version>
+            </dependency>
+			<dependency>
+				<groupId>javax.xml.bind</groupId>
+				<artifactId>jaxb-api</artifactId>
+				<version>${jaxb.version}</version>
 			</dependency>
         </dependencies>
     </dependencyManagement>
@@ -270,7 +286,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>${jacoco.version}</version>
+					<version>0.8.7</version>
 					<configuration>
 						<includes>
 							<include>uk/ac/manchester/**</include>
@@ -304,6 +320,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 					<groupId>org.eluder.coveralls</groupId>
 					<artifactId>coveralls-maven-plugin</artifactId>
 					<version>4.3.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-project-info-reports-plugin</artifactId>
+					<version>3.2.2</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jxr-plugin</artifactId>
+					<version>3.1.1</version>
 				</plugin>
             </plugins>
         </pluginManagement>
@@ -528,7 +554,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 								<dependency>
 									<groupId>javax.xml.bind</groupId>
 									<artifactId>jaxb-api</artifactId>
-									<version>2.3.1</version>
+									<version>${jaxb.version}</version>
 								</dependency>
 							</dependencies>
 						</plugin>


### PR DESCRIPTION
This puts the version info into the root POM instead of scattering it all over. It also removes many version properties that are only used once within the same file.