### PR TITLE
Use Java 8 

### DIFF
--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/job_parameters/GitPyNNJobParametersFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/job_parameters/GitPyNNJobParametersFactory.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.cs.spinnaker.job_parameters;
 
+import static java.util.Objects.nonNull;
 import static org.eclipse.jgit.api.Git.cloneRepository;
 
 import java.io.File;
@@ -85,9 +86,9 @@ class GitPyNNJobParametersFactory extends JobParametersFactory {
             URISyntaxException {
         final CloneCommand clone = cloneRepository();
         URIish urish = new URIish(experimentDescription);
-        if (urish.getUser() != null) {
+        if (nonNull(urish.getUser())) {
             String pass = urish.getPass();
-            if (pass == null) {
+            if (nonNull(pass)) {
                 pass = "";
             }
             clone.setCredentialsProvider(
@@ -108,7 +109,7 @@ class GitPyNNJobParametersFactory extends JobParametersFactory {
 
         String script = DEFAULT_SCRIPT_NAME + SYSTEM_ARG;
         final String command = job.getCommand();
-        if ((command != null) && !command.isEmpty()) {
+        if (nonNull(command) && !command.isEmpty()) {
             script = command;
         }
 

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/job_parameters/JobParametersFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/job_parameters/JobParametersFactory.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.cs.spinnaker.job_parameters;
 
+import static java.util.Objects.nonNull;
+
 import java.io.File;
 import java.util.Map;
 
@@ -84,7 +86,7 @@ public abstract class JobParametersFactory {
                 final JobParameters parameters =
                         factory.getJobParameters(job, workingDirectory,
                                 setupScript);
-                if (parameters != null) {
+                if (nonNull(parameters)) {
                     return parameters;
                 }
             } catch (final UnsupportedJobException e) {

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/job_parameters/ZipPyNNJobParametersFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/job_parameters/ZipPyNNJobParametersFactory.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.cs.spinnaker.job_parameters;
 
+import static java.util.Objects.nonNull;
 import static org.rauschig.jarchivelib.ArchiverFactory.createArchiver;
 import static org.rauschig.jarchivelib.CompressionType.BZIP2;
 import static org.rauschig.jarchivelib.CompressionType.GZIP;
@@ -195,7 +196,7 @@ class ZipPyNNJobParametersFactory extends JobParametersFactory {
 
         String script = DEFAULT_SCRIPT_NAME + SYSTEM_ARG;
         final String command = job.getCommand();
-        if ((command != null) && !command.isEmpty()) {
+        if (nonNull(command) && !command.isEmpty()) {
             script = command;
         }
 

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/JobProcessFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/JobProcessFactory.java
@@ -17,6 +17,7 @@
 package uk.ac.manchester.cs.spinnaker.jobprocess;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -102,10 +103,16 @@ public class JobProcessFactory {
      *             If there is an error creating the class
      * @throws InstantiationException
      *             If there is an error creating the class
+     * @throws SecurityException
+     * @throws NoSuchMethodException
+     * @throws InvocationTargetException
+     * @throws IllegalArgumentException
      */
     public <P extends JobParameters> JobProcess<P>
             createProcess(final P parameters)
-                    throws InstantiationException, IllegalAccessException {
+                    throws InstantiationException, IllegalAccessException,
+                    IllegalArgumentException, InvocationTargetException,
+                    NoSuchMethodException, SecurityException {
         /*
          * We know that this is of the correct type, because the addMapping
          * method will only allow the correct type mapping in
@@ -114,7 +121,8 @@ public class JobProcessFactory {
         final Class<JobProcess<P>> processType =
                 (Class<JobProcess<P>>) typeMap.get(parameters.getClass());
 
-        final JobProcess<P> process = processType.newInstance();
+        final JobProcess<P> process =
+                processType.getDeclaredConstructor().newInstance();
 
         // Magically set the thread group if there is one
         setField(process, "threadGroup", threadGroup);

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/JobProcessFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/JobProcessFactory.java
@@ -58,29 +58,30 @@ public class JobProcessFactory {
     }
 
     /**
-	 * A version of {@link java.util.function.Supplier Supplier} that builds a
-	 * job process. Required to work around type inference rules.
-	 *
-	 * @param <P> The type of job parameters
-	 * @author Donal Fellows
-	 */
+     * A version of {@link java.util.function.Supplier Supplier} that builds a
+     * job process. Required to work around type inference rules.
+     *
+     * @param <P>
+     *            The type of job parameters handled by the job process this
+     *            supplier produces.
+     */
     @FunctionalInterface
     public interface ProcessSupplier<P extends JobParameters> {
-		/**
-		 * Make a new instance of a job process.
-		 *
-		 * @return The instance.
-		 */
-    	JobProcess<P> get();
+        /**
+         * Make a new instance of a job process.
+         *
+         * @return The instance.
+         */
+        JobProcess<P> get();
     }
 
     /**
-	 * A map between parameter types and process types. Note that the type is
-	 * guaranteed by the {@link #addMapping(Class,ProcessSupplier)} method,
-	 * which is the only place that this map should be modified.
-	 */
-	private final Map<Class<? extends JobParameters>,
-			ProcessSupplier<? extends JobParameters>> typeMap = new HashMap<>();
+     * A map between parameter types and process types. Note that the type is
+     * guaranteed by the {@link #addMapping(Class,ProcessSupplier)} method,
+     * which is the only place that this map should be modified.
+     */
+    private final Map<Class<? extends JobParameters>,
+            ProcessSupplier<? extends JobParameters>> typeMap = new HashMap<>();
 
     /**
      * Adds a new type mapping.
@@ -135,7 +136,7 @@ public class JobProcessFactory {
          */
         @SuppressWarnings("unchecked")
         final JobProcess<P> process =
-        		(JobProcess<P>) typeMap.get(parameters.getClass()).get();
+                (JobProcess<P>) typeMap.get(parameters.getClass()).get();
 
         // Magically set the thread group if there is one
         setField(process, "threadGroup", threadGroup);

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/JobProcessFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/JobProcessFactory.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.cs.spinnaker.jobprocess;
 
+import static java.util.Objects.isNull;
+
 import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.HashMap;
@@ -123,7 +125,7 @@ public class JobProcessFactory {
         @SuppressWarnings("unchecked")
         final ProcessSupplier<P> supplier =
                 (ProcessSupplier<P>) typeMap.get(parameters.getClass());
-        if (supplier == null) {
+        if (isNull(supplier)) {
             throw new IllegalArgumentException(
                     "unsupported job parameter type: " + parameters.getClass());
         }

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/JobProcessFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/JobProcessFactory.java
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import uk.ac.manchester.cs.spinnaker.job.JobParameters;
 
@@ -58,26 +59,21 @@ public class JobProcessFactory {
     }
 
     /**
-     * A version of {@link java.util.function.Supplier Supplier} that builds a
-     * job process. Required to work around type inference rules.
+     * A version of {@link Supplier} that builds a job process. Required to work
+     * around type inference rules.
      *
      * @param <P>
      *            The type of job parameters handled by the job process this
      *            supplier produces.
      */
     @FunctionalInterface
-    public interface ProcessSupplier<P extends JobParameters> {
-        /**
-         * Make a new instance of a job process.
-         *
-         * @return The instance.
-         */
-        JobProcess<P> get();
+    public interface ProcessSupplier<P extends JobParameters>
+            extends Supplier<JobProcess<P>> {
     }
 
     /**
-     * A map between parameter types and process types. Note that the type is
-     * guaranteed by the {@link #addMapping(Class,ProcessSupplier)} method,
+     * A map between parameter types and process suppliers. Note that the type
+     * is guaranteed by the {@link #addMapping(Class,ProcessSupplier)} method,
      * which is the only place that this map should be modified.
      */
     private final Map<Class<? extends JobParameters>,
@@ -90,13 +86,13 @@ public class JobProcessFactory {
      *            The type of parameters that this mapping will handle.
      * @param parameterType
      *            The job parameter type
-     * @param processType
-     *            The job process type
+     * @param processSupplier
+     *            The job process supplier
      */
     public <P extends JobParameters> void addMapping(
             final Class<P> parameterType,
-            final ProcessSupplier<P> processType) {
-        typeMap.put(parameterType, processType);
+            final ProcessSupplier<P> processSupplier) {
+        typeMap.put(parameterType, processSupplier);
     }
 
     /**

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
@@ -21,6 +21,9 @@ import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.commons.io.FileUtils.listFiles;
 import static org.apache.commons.io.FilenameUtils.getExtension;
+import static org.apache.commons.io.IOUtils.buffer;
+import static org.apache.commons.io.IOUtils.closeQuietly;
+import static org.apache.commons.io.IOUtils.copy;
 import static uk.ac.manchester.cs.spinnaker.job.Status.Error;
 import static uk.ac.manchester.cs.spinnaker.job.Status.Finished;
 import static uk.ac.manchester.cs.spinnaker.job.Status.Running;
@@ -73,12 +76,6 @@ import uk.ac.manchester.cs.spinnaker.utils.ThreadUtils;
  * A process for running PyNN jobs.
  */
 public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
-
-    /**
-     * The size of buffer to use when transferring data between files.
-     */
-    private static final int BUFFER_SIZE = 8196;
-
     /**
      * The error level that represents a signal.
      */
@@ -461,7 +458,7 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
             for (final String item : PROVENANCE_ITEMS_TO_ADD) {
                 if (itemPath.matches(item)) {
                     provenance.add(new ProvenanceItem(
-                        new ArrayList<>(pathList), subItem.getValue()));
+                            new ArrayList<>(pathList), subItem.getValue()));
                 }
             }
             pathList.removeLast();
@@ -519,7 +516,6 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
             throws IOException, JAXBException {
 
         // Go through the report files and zip them up
-        final byte[] buffer = new byte[BUFFER_SIZE];
         for (final File file : directory.listFiles()) {
             if (file.isDirectory()) {
                 zipProvenance(reportsZip, file, path + "/" + file.getName());
@@ -529,15 +525,10 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
                     addProvenance(file);
                 }
             } else {
-                final ZipEntry entry =
-                        new ZipEntry(path + "/" + file.getName());
-                reportsZip.putNextEntry(entry);
+                reportsZip.putNextEntry(
+                        new ZipEntry(path + "/" + file.getName()));
                 try (FileInputStream in = new FileInputStream(file)) {
-                    int bytesRead = in.read(buffer);
-                    while (bytesRead >= 0) {
-                        reportsZip.write(buffer, 0, bytesRead);
-                        bytesRead = in.read(buffer);
-                    }
+                    copy(in, reportsZip);
                 }
             }
         }
@@ -642,12 +633,7 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
         ReaderLogWriter(
                 final Reader readerParam, final LogWriter writerParam) {
             super(threadGroup, "Reader Log Writer");
-            requireNonNull(readerParam);
-            if (readerParam instanceof BufferedReader) {
-                this.reader = (BufferedReader) readerParam;
-            } else {
-                this.reader = new BufferedReader(readerParam);
-            }
+            this.reader = buffer(readerParam);
             this.writer = requireNonNull(writerParam);
             setDaemon(true);
         }
@@ -719,11 +705,7 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
             }
 
             log("Log writer has exited");
-            try {
-                reader.close();
-            } catch (IOException | RuntimeException e) {
-                // Do nothing
-            }
+            closeQuietly(reader);
             ThreadUtils.sleep(FINALIZATION_DELAY);
         }
     }

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocess/PyNNJobProcess.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.cs.spinnaker.jobprocess;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -249,11 +251,11 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
             } else {
                 section = ini.get(SECTION);
             }
-            if (machine != null) {
+            if (nonNull(machine)) {
                 section.put("machine_name", machine.getMachineName());
                 section.put("version", machine.getVersion());
                 final String bmpDetails = machine.getBmpDetails();
-                if (bmpDetails != null) {
+                if (nonNull(bmpDetails)) {
                     section.put("bmp_names", bmpDetails);
                 }
             } else {
@@ -680,7 +682,7 @@ public class PyNNJobProcess implements JobProcess<PyNNJobParameters> {
         private void copyStream() throws IOException {
             while (!interrupted()) {
                 final String line = reader.readLine();
-                if (line == null) {
+                if (isNull(line)) {
                     return;
                 }
                 writer.append(line + "\n");

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/JobProcessManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/JobProcessManager.java
@@ -18,6 +18,8 @@ package uk.ac.manchester.cs.spinnaker.jobprocessmanager;
 
 import static java.lang.String.format;
 import static java.lang.System.exit;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.apache.commons.io.IOUtils.buffer;
@@ -121,7 +123,7 @@ public class JobProcessManager {
                         toWrite = takeCache();
                     }
                 }
-                if (toWrite != null && !toWrite.isEmpty()) {
+                if (nonNull(toWrite) && !toWrite.isEmpty()) {
                     log("Sending cached data to job manager");
                     jobManager.appendLog(job.getId(), toWrite);
                 }
@@ -291,19 +293,19 @@ public class JobProcessManager {
      * @param error The error of the failure.
      */
     private void reportFailure(final Throwable error) {
-        if ((jobManager == null) || (job == null)) {
+        if (isNull(jobManager) || isNull(job)) {
             log(error);
             return;
         }
 
         try {
             String log = "";
-            if (logWriter != null) {
+            if (nonNull(logWriter)) {
                 logWriter.stop();
                 log = logWriter.getLog();
             }
             String message = error.getMessage();
-            if (message == null) {
+            if (isNull(message)) {
                 message = "No Error Message";
             }
             jobManager.setJobError(projectId, job.getId(), message, log, "",
@@ -406,7 +408,7 @@ public class JobProcessManager {
         final JobParameters parameters = JobParametersFactory
                 .getJobParameters(job, workingDirectory, setupScript, errors);
 
-        if (parameters == null) {
+        if (isNull(parameters)) {
             if (!errors.isEmpty()) {
                 throw new JobErrorsException(errors);
             }
@@ -416,7 +418,7 @@ public class JobProcessManager {
         }
 
         // Get any requested input files
-        if (job.getInputData() != null) {
+        if (nonNull(job.getInputData())) {
             for (final DataItem input : job.getInputData()) {
                 downloadFile(input.getUrl(), workingDirectory, null);
             }
@@ -473,7 +475,7 @@ public class JobProcessManager {
             case Error :
                 final Throwable error = process.getError();
                 String message = error.getMessage();
-                if (message == null) {
+                if (isNull(message)) {
                     message = "No Error Message";
                 }
                 jobManager.setJobError(projectId, job.getId(), message, log,
@@ -547,7 +549,7 @@ class Machine {
 
     @Override
     public String toString() {
-        if (machine != null) {
+        if (nonNull(machine)) {
             return machine.toString();
         }
         return url;

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/JobProcessManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/JobProcessManager.java
@@ -20,6 +20,7 @@ import static java.lang.String.format;
 import static java.lang.System.exit;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.io.FileUtils.deleteQuietly;
+import static org.apache.commons.io.IOUtils.buffer;
 import static org.eclipse.jgit.util.FileUtils.createTempDir;
 import static uk.ac.manchester.cs.spinnaker.jobprocessmanager.RemoteSpiNNakerAPI.createJobManager;
 import static uk.ac.manchester.cs.spinnaker.utils.FileDownloader.downloadFile;
@@ -354,7 +355,7 @@ public class JobProcessManager {
                     requestMachine = true;
                     break;
                 case "--authToken" :
-                    try (BufferedReader r = new BufferedReader(
+                    try (BufferedReader r = buffer(
                             new InputStreamReader(System.in))) {
                         authToken = r.readLine();
                     }

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/JobProcessManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/JobProcessManager.java
@@ -25,8 +25,6 @@ import static uk.ac.manchester.cs.spinnaker.jobprocessmanager.RemoteSpiNNakerAPI
 import static uk.ac.manchester.cs.spinnaker.utils.FileDownloader.downloadFile;
 import static uk.ac.manchester.cs.spinnaker.utils.Log.log;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -102,18 +100,13 @@ public class JobProcessManager {
         /**
          * An object to synchronise on when sending data.
          */
-        private final Integer sendSync = new Integer(0);
+        private final Object sendSync = new Object();
 
         /**
          * Make a log writer that uploads the log every half second.
          */
         UploadingJobManagerLogWriter() {
-            sendTimer = new Timer(UPDATE_INTERVAL, new ActionListener() {
-                @Override
-                public void actionPerformed(final ActionEvent e) {
-                    sendLog();
-                }
-            });
+            sendTimer = new Timer(UPDATE_INTERVAL, e -> sendLog());
         }
 
         /**

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/JobProcessManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/JobProcessManager.java
@@ -84,7 +84,7 @@ public class JobProcessManager {
             new JobProcessFactory("JobProcess");
     static {
         JOB_PROCESS_FACTORY.addMapping(PyNNJobParameters.class,
-                PyNNJobProcess.class);
+                PyNNJobProcess::new);
     }
 
     /**

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/JobProcessManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/JobProcessManager.java
@@ -256,7 +256,6 @@ public class JobProcessManager {
             final File setupScript = downloadFile(downloadUrl,
                     workingDirectory, JobManagerInterface.SETUP_SCRIPT);
 
-
             final JobParameters parameters = getJobParameters(
                     workingDirectory, setupScript.getAbsolutePath());
 

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/RemoteSpiNNakerAPI.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/RemoteSpiNNakerAPI.java
@@ -17,6 +17,7 @@
 package uk.ac.manchester.cs.spinnaker.jobprocessmanager;
 
 import static jakarta.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static java.util.Objects.nonNull;
 import static org.apache.commons.codec.binary.Base64.encodeBase64String;
 
 import java.nio.charset.Charset;
@@ -82,7 +83,7 @@ public abstract class RemoteSpiNNakerAPI {
         mapper.registerModule(new JodaModule());
         provider.setMapper(mapper);
         client.register(provider);
-        if (authToken != null) {
+        if (nonNull(authToken)) {
             client.register(getBasicAuthFilter(authToken));
         }
         return client.target(url).proxy(JobManagerInterface.class);

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/FileDownloader.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/FileDownloader.java
@@ -18,6 +18,8 @@ package uk.ac.manchester.cs.spinnaker.utils;
 
 import static java.io.File.createTempFile;
 import static java.nio.file.Files.copy;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
@@ -26,9 +28,10 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
-import java.util.Map;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.util.Map;
+
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -57,7 +60,7 @@ public abstract class FileDownloader {
      * @return The filename
      */
     private static String getFileName(final String contentDisposition) {
-        if (contentDisposition != null) {
+        if (nonNull(contentDisposition)) {
             final String cdl = contentDisposition.toLowerCase();
             if (cdl.startsWith("form-data") || cdl.startsWith("attachment")) {
                 final ParameterParser parser = new ParameterParser();
@@ -91,7 +94,7 @@ public abstract class FileDownloader {
         }
 
         urlConnection.setRequestProperty("Accept", "*/*");
-        if (userInfo != null && urlConnection instanceof HttpURLConnection) {
+        if (nonNull(userInfo) && urlConnection instanceof HttpURLConnection) {
             HttpURLConnection httpConnection =
                 (HttpURLConnection) urlConnection;
             String basicAuth = "Basic " + Base64.encodeBase64URLSafeString(
@@ -122,7 +125,7 @@ public abstract class FileDownloader {
 
         // Open a connection
         String userInfo = url.getUserInfo();
-        if (userInfo != null) {
+        if (nonNull(userInfo)) {
             userInfo = URLDecoder.decode(url.getUserInfo(), "UTF8");
         }
         URLConnection urlConnection = createConnectionWithAuth(url, userInfo);
@@ -138,7 +141,7 @@ public abstract class FileDownloader {
                 if (responseCode == HttpURLConnection.HTTP_MOVED_TEMP
                         || responseCode == HttpURLConnection.HTTP_MOVED_PERM) {
                     String location = httpConnection.getHeaderField("Location");
-                    if (location == null) {
+                    if (isNull(location)) {
                         location = url.toString();
                     }
                     urlConnection = createConnectionWithAuth(
@@ -214,10 +217,10 @@ public abstract class FileDownloader {
             final URLConnection urlConnection) throws IOException {
         final String filename = getFileName(
                 urlConnection.getHeaderField("Content-Disposition"));
-        if (filename != null) {
+        if (nonNull(filename)) {
             return new File(workingDirectory, filename);
         }
-        if (defaultFilename != null) {
+        if (nonNull(defaultFilename)) {
             return new File(workingDirectory, defaultFilename);
         }
         final String path = url.getPath();

--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/FileDownloader.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/utils/FileDownloader.java
@@ -29,10 +29,8 @@ import java.net.URLDecoder;
 import java.util.Map;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
-import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
@@ -194,13 +192,7 @@ public abstract class FileDownloader {
             sc.init(null, new TrustManager[] {tm}, new SecureRandom());
 
             connection.setSSLSocketFactory(sc.getSocketFactory());
-            connection.setHostnameVerifier(new HostnameVerifier() {
-                @Override
-                public boolean verify(
-                        final String hostname, final SSLSession session) {
-                    return true;
-                }
-            });
+            connection.setHostnameVerifier((hostname, session) -> true);
         } catch (Exception e) {
             throw new IOException("Error processing HTTPS request", e);
         }

--- a/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/machine/SpinnakerMachine.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/machine/SpinnakerMachine.java
@@ -17,8 +17,11 @@
 package uk.ac.manchester.cs.spinnaker.machine;
 
 import static java.lang.Integer.parseInt;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Represents a SpiNNaker machine on which jobs can be executed.
@@ -145,8 +148,8 @@ public class SpinnakerMachine
 
         for (Object potential : new Object[]{
                 machineName, version, bmpDetails, width, height, bmpDetails}) {
-            if (potential != null) {
-                if (output == null) {
+            if (nonNull(potential)) {
+                if (isNull(output)) {
                     output = potential.toString();
                 } else {
                     output += ":" + potential.toString();
@@ -311,29 +314,8 @@ public class SpinnakerMachine
         if (o instanceof SpinnakerMachine) {
             // TODO Is this the right way to determine equality?
             final SpinnakerMachine m = (SpinnakerMachine) o;
-            if (machineName == null) {
-                if (m.machineName != null) {
-                    return false;
-                }
-            } else if (m.machineName == null) {
-                return false;
-            } else {
-                if (!machineName.equals(m.machineName)) {
-                    return false;
-                }
-            }
-            if (version == null) {
-                if (m.version != null) {
-                    return false;
-                }
-            } else if (m.version == null) {
-                return false;
-            } else {
-                if (!version.equals(m.version)) {
-                    return false;
-                }
-            }
-            return true;
+            return Objects.equals(machineName, m.machineName)
+                    && Objects.equals(version, m.version);
         } else {
             return false;
         }
@@ -345,26 +327,26 @@ public class SpinnakerMachine
     @Override
     public int compareTo(final SpinnakerMachine m) {
         int cmp = 0;
-        if (machineName == null) {
-            if (m.machineName == null) {
+        if (isNull(machineName)) {
+            if (isNull(m.machineName)) {
                 cmp = 0;
             } else {
                 cmp = -1;
             }
-        } else if (m.machineName == null) {
+        } else if (isNull(m.machineName)) {
             cmp = 1;
         } else {
             cmp = machineName.compareTo(m.machineName);
         }
         if (cmp == 0) {
             // TODO Is this the right way to compare versions? It works...
-            if (version == null) {
-                if (m.version == null) {
+            if (isNull(version)) {
+                if (isNull(m.version)) {
                     cmp = 0;
                 } else {
                     cmp = -1;
                 }
-            } else if (m.version == null) {
+            } else if (isNull(m.version)) {
                 cmp = 1;
             } else {
                 cmp = version.compareTo(m.version);
@@ -378,12 +360,12 @@ public class SpinnakerMachine
      */
     @Override
     public int hashCode() {
-        // TODO Should be consistent with equality tests
+        // Must be consistent with equality tests
         int hc = 0;
-        if (machineName != null) {
+        if (nonNull(machineName)) {
             hc ^= machineName.hashCode();
         }
-        if (version != null) {
+        if (nonNull(version)) {
             hc ^= version.hashCode();
         }
         return hc;

--- a/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/machine/SpinnakerMachine.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerModel/src/main/java/uk/ac/manchester/cs/spinnaker/machine/SpinnakerMachine.java
@@ -17,10 +17,13 @@
 package uk.ac.manchester.cs.spinnaker.machine;
 
 import static java.lang.Integer.parseInt;
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.nullsFirst;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 import java.io.Serializable;
+import java.util.Comparator;
 import java.util.Objects;
 
 /**
@@ -321,38 +324,22 @@ public class SpinnakerMachine
         }
     }
 
+    /** Null-safe string comparator. */
+    private static final Comparator<String> STRCMP =
+            nullsFirst(String::compareTo);
+
+    /** Machine comparator. */
+    private static final Comparator<SpinnakerMachine> M_COMPARE =
+            comparing(SpinnakerMachine::getMachineName, STRCMP)
+                    // TODO Is this the right way to compare versions? It works
+                    .thenComparing(SpinnakerMachine::getVersion, STRCMP);
+
     /**
      * Compare to another machine; order by name then by version.
      */
     @Override
     public int compareTo(final SpinnakerMachine m) {
-        int cmp = 0;
-        if (isNull(machineName)) {
-            if (isNull(m.machineName)) {
-                cmp = 0;
-            } else {
-                cmp = -1;
-            }
-        } else if (isNull(m.machineName)) {
-            cmp = 1;
-        } else {
-            cmp = machineName.compareTo(m.machineName);
-        }
-        if (cmp == 0) {
-            // TODO Is this the right way to compare versions? It works...
-            if (isNull(version)) {
-                if (isNull(m.version)) {
-                    cmp = 0;
-                } else {
-                    cmp = -1;
-                }
-            } else if (isNull(m.version)) {
-                cmp = 1;
-            } else {
-                cmp = version.compareTo(m.version);
-            }
-        }
-        return cmp;
+        return M_COMPARE.compare(this, m);
     }
 
     /**

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/TestRestClient.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/TestRestClient.java
@@ -26,12 +26,9 @@ import uk.ac.manchester.cs.spinnaker.job.nmpi.Job;
 import uk.ac.manchester.cs.spinnaker.job.nmpi.QueueEmpty;
 import uk.ac.manchester.cs.spinnaker.job.nmpi.QueueNextResponse;
 import uk.ac.manchester.cs.spinnaker.rest.NMPIQueue;
-import uk.ac.manchester.cs.spinnaker.rest.utils.CustomJacksonJsonProvider;
-import uk.ac.manchester.cs.spinnaker.rest.utils.PropertyBasedDeserialiser;
 
 /**
  * Testing.
- *
  */
 public final class TestRestClient {
 
@@ -48,34 +45,13 @@ public final class TestRestClient {
      * @throws Exception if anything goes wrong
      */
     public static void main(final String[] args) throws Exception {
-        final CustomJacksonJsonProvider provider =
-                new CustomJacksonJsonProvider();
-
-        /**
-         * How to understand messages coming from the queue.
-         */
-        @SuppressWarnings("serial")
-        class QueueResponseDeserialiser
-                extends PropertyBasedDeserialiser<QueueNextResponse> {
-            /**
-             * Make a deserialiser.
-             */
-            QueueResponseDeserialiser() {
-                super(QueueNextResponse.class);
-                register("id", Job.class);
-                register("warning", QueueEmpty.class);
-            }
-        }
-        provider.addDeserialiser(QueueNextResponse.class,
-                new QueueResponseDeserialiser());
-
         URL nmpiUrl = new URL("https://nmpi.hbpneuromorphic.eu/");
         String nmpiUsername = "uman";
         String apiKey = "QWvPf6WzISelx7MhIJqzoi-BgZqj95PPJYnpBuLTKcGN5b8sbP9"
                 + "fiUR2UQ6I--PHuoeOIeF0tmKptKC5rbIMRiRlGGG51zDvRDzqoIVTm4LU6L"
                 + "fV8MXYRlzXi4Dc75w-";
         NMPIQueue queue = createApiKeyClient(nmpiUrl, nmpiUsername, apiKey,
-                NMPIQueue.class, provider);
+                NMPIQueue.class, NMPIQueue.createProvider());
         QueueNextResponse response = queue.getNextJob("SpiNNaker");
         if (response instanceof QueueEmpty) {
             System.err.println("No items in queue");

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/JobExecuter.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/JobExecuter.java
@@ -23,7 +23,6 @@ package uk.ac.manchester.cs.spinnaker.jobmanager;
  * @see XenVMExecuterFactory.Executer
  */
 public interface JobExecuter {
-
     /**
      * Gets the id of the executer.
      *

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/LocalJobExecuterFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/LocalJobExecuterFactory.java
@@ -420,9 +420,11 @@ public class LocalJobExecuterFactory implements JobExecuterFactory {
         @Override
         public void run() {
             try {
-                String line;
-                while (!done && nonNull(line = readLine())) {
-                    if (!line.isEmpty()) {
+                while (!done) {
+                    String line = readLine();
+                    if (isNull(line)) {
+                        break;
+                    } else if (!line.isEmpty()) {
                         logger.debug("{}", line);
                         writer.println(line);
                     }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/LocalJobExecuterFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/LocalJobExecuterFactory.java
@@ -18,6 +18,8 @@ package uk.ac.manchester.cs.spinnaker.jobmanager;
 
 import static java.io.File.createTempFile;
 import static java.io.File.pathSeparator;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.io.FileUtils.copyToFile;
@@ -133,7 +135,7 @@ public class LocalJobExecuterFactory implements JobExecuterFactory {
         // Find the JobManager resource
         final InputStream jobManagerStream =
                 getClass().getResourceAsStream("/" + JOB_PROCESS_MANAGER_ZIP);
-        if (jobManagerStream == null) {
+        if (isNull(jobManagerStream)) {
             throw new UnsatisfiedLinkError(
                     "/" + JOB_PROCESS_MANAGER_ZIP + " not found in classpath");
         }
@@ -146,7 +148,7 @@ public class LocalJobExecuterFactory implements JobExecuterFactory {
 
         // Extract the JobManager resources
         try (ZipInputStream input = new ZipInputStream(jobManagerStream)) {
-            for (ZipEntry entry = input.getNextEntry(); entry != null;
+            for (ZipEntry entry = input.getNextEntry(); nonNull(entry);
                     entry = input.getNextEntry()) {
                 if (entry.isDirectory()) {
                     continue;
@@ -350,10 +352,10 @@ public class LocalJobExecuterFactory implements JobExecuterFactory {
          */
         OutputStream getProcessOutputStream() throws IOException {
             synchronized (this) {
-                while ((process == null) && (startException == null)) {
+                while (isNull(process) && isNull(startException)) {
                     waitfor(this);
                 }
-                if (startException != null) {
+                if (nonNull(startException)) {
                     throw startException;
                 }
                 return process.getOutputStream();
@@ -419,7 +421,7 @@ public class LocalJobExecuterFactory implements JobExecuterFactory {
         public void run() {
             try {
                 String line;
-                while (!done && (line = readLine()) != null) {
+                while (!done && nonNull(line = readLine())) {
                     if (!line.isEmpty()) {
                         logger.debug("{}", line);
                         writer.println(line);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/LocalJobExecuterFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/LocalJobExecuterFactory.java
@@ -280,7 +280,7 @@ public class LocalJobExecuterFactory implements JobExecuterFactory {
             command.add(javaExec.getAbsolutePath());
 
             String classPath = jobProcessManagerClasspath.stream()
-            		.map(File::toString).collect(joining(pathSeparator));
+                    .map(File::toString).collect(joining(pathSeparator));
             command.add("-cp");
             command.add(classPath);
             logger.debug("Classpath: {}", classPath);
@@ -329,9 +329,9 @@ public class LocalJobExecuterFactory implements JobExecuterFactory {
          * Report the results of the job using the log.
          */
         private void reportResult() {
-        	StringWriter loggedOutput = new StringWriter();
+            StringWriter loggedOutput = new StringWriter();
             try (FileReader reader = new FileReader(outputLog)) {
-            	IOUtils.copy(reader, loggedOutput);
+                IOUtils.copy(reader, loggedOutput);
             } catch (final IOException e) {
                 logger.warn("problem in reporting log", e);
             }
@@ -419,7 +419,7 @@ public class LocalJobExecuterFactory implements JobExecuterFactory {
         @Override
         public void run() {
             try {
-            	String line;
+                String line;
                 while (!done && (line = readLine()) != null) {
                     if (!line.isEmpty()) {
                         logger.debug("{}", line);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/XenVMExecuterFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/XenVMExecuterFactory.java
@@ -23,6 +23,7 @@ import static com.xensource.xenapi.Types.VbdType.DISK;
 import static com.xensource.xenapi.Types.VdiType.USER;
 import static com.xensource.xenapi.Types.VmPowerState.HALTED;
 import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.cs.spinnaker.job.JobManagerInterface.JOB_PROCESS_MANAGER_ZIP;
 import static uk.ac.manchester.cs.spinnaker.jobmanager.JobManager.JOB_PROCESS_MANAGER_JAR;
@@ -31,7 +32,6 @@ import static uk.ac.manchester.cs.spinnaker.utils.ThreadUtils.sleep;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Set;
-import java.util.UUID;
 
 import org.apache.xmlrpc.XmlRpcException;
 import org.slf4j.Logger;
@@ -188,7 +188,6 @@ public class XenVMExecuterFactory implements JobExecuterFactory {
 
     /** Taming the Xen API a bit. */
     class XenConnection implements AutoCloseable {
-
         /**
          * The Xen connection.
          */
@@ -444,7 +443,7 @@ public class XenVMExecuterFactory implements JobExecuterFactory {
     /**
      * The executer core connector.
      */
-    class Executer implements JobExecuter {
+    protected class Executer implements JobExecuter {
         // Parameters from constructor
         /**
          * The Job Manager to report to.
@@ -508,7 +507,7 @@ public class XenVMExecuterFactory implements JobExecuterFactory {
         Executer(final JobManager jobManagerParam, final URL baseUrl)
                 throws XmlRpcException, IOException {
             this.jobManager = jobManagerParam;
-            uuid = UUID.randomUUID().toString();
+            uuid = randomUUID().toString();
             jobProcessManagerUrl =
                     new URL(baseUrl, "job/" + JOB_PROCESS_MANAGER_ZIP);
 
@@ -596,36 +595,60 @@ public class XenVMExecuterFactory implements JobExecuterFactory {
             }
         }
 
-        private void runInVm() {
-            XenConnection conn = null;
+        /**
+         * Wait until the running VM shuts down.
+         *
+         * @param conn The connection to Xen
+         * @throws XenAPIException If there is a Xen API issue
+         * @throws XmlRpcException If there is an error speaking to Xen
+         */
+        private void waitForHalt(XenConnection conn)
+                throws XenAPIException, XmlRpcException {
+            VmPowerState powerState;
+            do {
+                sleep(VM_POLL_INTERVAL);
+                powerState = conn.getState(clonedVm);
+                logger.debug("VM for {} is in state {}", uuid, powerState);
+            } while (powerState != HALTED);
+        }
+
+        /**
+         * Run the VM.
+         *
+         * @param conn The connection to Xen
+         */
+        private void runInVm(XenConnection conn) {
+            String action = null;
             try {
-                conn = new XenConnection(uuid);
+                action = "setting up VM";
                 createVm(conn);
-                try {
-                    VmPowerState powerState;
-                    do {
-                        sleep(VM_POLL_INTERVAL);
-                        powerState = conn.getState(clonedVm);
-                        logger.debug("VM for {} is in state {}", uuid,
-                                powerState);
-                    } while (powerState != HALTED);
-                } catch (final Exception e) {
-                    logger.error("Could not get VM power state, assuming off",
-                            e);
-                } finally {
-                    jobManager.setExecutorExited(uuid, null);
-                }
+                action = "getting VM power state; assuming off";
+                waitForHalt(conn);
+                jobManager.setExecutorExited(uuid, null);
             } catch (final Exception e) {
-                logger.error("Error setting up VM", e);
+                logger.error("Error {}", action, e);
                 jobManager.setExecutorExited(uuid, e.getMessage());
             } finally {
                 try {
-                    if (conn != null && deleteOnExit) {
+                    if (deleteOnExit) {
                         deleteVm(conn);
                     }
                 } catch (final Exception e) {
-                    logger.error("Error deleting VM");
+                    logger.error("Error deleting VM", e);
                 }
+            }
+        }
+
+        /**
+         * Connect to Xen and run the VM. Notifies the factory when done.
+         */
+        private void runInVm() {
+            try (XenConnection conn = new XenConnection(uuid)) {
+                runInVm(conn);
+            } catch (final Exception e) {
+                logger.error("Error talking to Xen", e);
+                jobManager.setExecutorExited(uuid, e.getMessage());
+            } finally {
                 executorFinished();
             }
         }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/XenVMExecuterFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/XenVMExecuterFactory.java
@@ -444,7 +444,7 @@ public class XenVMExecuterFactory implements JobExecuterFactory {
     /**
      * The executer core connector.
      */
-    class Executer implements JobExecuter, Runnable {
+    class Executer implements JobExecuter {
         // Parameters from constructor
         /**
          * The Job Manager to report to.
@@ -537,7 +537,8 @@ public class XenVMExecuterFactory implements JobExecuterFactory {
 
         @Override
         public void startExecuter() {
-            new Thread(threadGroup, this, "Executer (" + uuid + ")").start();
+            new Thread(threadGroup, this::runInVm,
+                    "Executer (" + uuid + ")").start();
         }
 
         /**
@@ -595,8 +596,7 @@ public class XenVMExecuterFactory implements JobExecuterFactory {
             }
         }
 
-        @Override
-        public void run() {
+        private void runInVm() {
             XenConnection conn = null;
             try {
                 conn = new XenConnection(uuid);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/XenVMExecuterFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/XenVMExecuterFactory.java
@@ -602,7 +602,7 @@ public class XenVMExecuterFactory implements JobExecuterFactory {
          * @throws XenAPIException If there is a Xen API issue
          * @throws XmlRpcException If there is an error speaking to Xen
          */
-        private void waitForHalt(XenConnection conn)
+        private void waitForHalt(final XenConnection conn)
                 throws XenAPIException, XmlRpcException {
             VmPowerState powerState;
             do {
@@ -617,7 +617,7 @@ public class XenVMExecuterFactory implements JobExecuterFactory {
          *
          * @param conn The connection to Xen
          */
-        private void runInVm(XenConnection conn) {
+        private void runInVm(final XenConnection conn) {
             String action = null;
             try {
                 action = "setting up VM";

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/XenVMExecuterFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/XenVMExecuterFactory.java
@@ -22,6 +22,8 @@ import static com.xensource.xenapi.Types.VbdMode.RW;
 import static com.xensource.xenapi.Types.VbdType.DISK;
 import static com.xensource.xenapi.Types.VdiType.USER;
 import static com.xensource.xenapi.Types.VmPowerState.HALTED;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -572,22 +574,22 @@ public class XenVMExecuterFactory implements JobExecuterFactory {
          */
         private synchronized void deleteVm(final XenConnection conn)
                 throws XenAPIException, XmlRpcException {
-            if (conn == null) {
+            if (isNull(conn)) {
                 return;
             }
-            if (disk != null) {
+            if (nonNull(disk)) {
                 conn.destroy(disk);
             }
-            if (extraDisk != null) {
+            if (nonNull(extraDisk)) {
                 conn.destroy(extraDisk);
             }
-            if (vdi != null) {
+            if (nonNull(vdi)) {
                 conn.destroy(vdi);
             }
-            if (extraVdi != null) {
+            if (nonNull(extraVdi)) {
                 conn.destroy(extraVdi);
             }
-            if (clonedVm != null) {
+            if (nonNull(clonedVm)) {
                 conn.destroy(clonedVm);
             }
         }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/XenVMExecuterFactory.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/jobmanager/XenVMExecuterFactory.java
@@ -28,6 +28,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.cs.spinnaker.job.JobManagerInterface.JOB_PROCESS_MANAGER_ZIP;
 import static uk.ac.manchester.cs.spinnaker.jobmanager.JobManager.JOB_PROCESS_MANAGER_JAR;
 import static uk.ac.manchester.cs.spinnaker.utils.ThreadUtils.sleep;
+import static uk.ac.manchester.cs.spinnaker.utils.ThreadUtils.waitfor;
 
 import java.io.IOException;
 import java.net.URL;
@@ -166,11 +167,7 @@ public class XenVMExecuterFactory implements JobExecuterFactory {
                 logger.debug("Waiting for a VM to become available "
                         + "({} of {} in use)", nVirtualMachines,
                         maxNVirtualMachines);
-                try {
-                    lock.wait();
-                } catch (final InterruptedException e) {
-                    // Does Nothing
-                }
+                waitfor(lock);
             }
             nVirtualMachines++;
         }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/FixedMachineManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/FixedMachineManagerImpl.java
@@ -100,12 +100,9 @@ public class FixedMachineManagerImpl implements MachineManager {
      * @return A machine big enough, or null of none.
      */
     private SpinnakerMachine getLargeEnoughMachine(final int nBoards) {
-        for (final SpinnakerMachine nextMachine : machinesAvailable) {
-            if (nextMachine.getnBoards() >= nBoards) {
-                return nextMachine;
-            }
-        }
-        return null;
+        return machinesAvailable.stream()
+                .filter(machine -> machine.getnBoards() >= nBoards)
+                .findFirst().orElse(null);
     }
 
     @Override

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/FixedMachineManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/FixedMachineManagerImpl.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.cs.spinnaker.machinemanager;
 
+import static uk.ac.manchester.cs.spinnaker.utils.ThreadUtils.waitfor;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -73,24 +75,22 @@ public class FixedMachineManagerImpl implements MachineManager {
 
     @Override
     public SpinnakerMachine getNextAvailableMachine(final int nBoards) {
-        try {
-            synchronized (lock) {
-                SpinnakerMachine machine;
-                while (!done) {
-                    machine = getLargeEnoughMachine(nBoards);
-                    if (machine != null) {
-                        // Move the machine from available to allocated
-                        machinesAvailable.remove(machine);
-                        machinesAllocated.add(machine);
-                        return machine;
-                    }
-                    // If no machine was found, wait for something to change
-                    lock.wait();
+        synchronized (lock) {
+            while (!done) {
+                final SpinnakerMachine machine = getLargeEnoughMachine(nBoards);
+                if (machine != null) {
+                    // Move the machine from available to allocated
+                    machinesAvailable.remove(machine);
+                    machinesAllocated.add(machine);
+                    return machine;
+                }
+                // If no machine was found, wait for something to change
+                if (waitfor(lock)) {
+                    break;
                 }
             }
-        } catch (final InterruptedException e) {
+            return null;
         }
-        return null;
     }
 
     /**
@@ -134,11 +134,7 @@ public class FixedMachineManagerImpl implements MachineManager {
             final int waitTime) {
         synchronized (lock) {
             final boolean isAvailable = machinesAvailable.contains(machine);
-            try {
-                lock.wait(waitTime);
-            } catch (final InterruptedException e) {
-                // Does Nothing
-            }
+            waitfor(lock, waitTime);
             return machinesAvailable.contains(machine) != isAvailable;
         }
     }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/FixedMachineManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/FixedMachineManagerImpl.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.cs.spinnaker.machinemanager;
 
+import static java.util.Objects.nonNull;
 import static uk.ac.manchester.cs.spinnaker.utils.ThreadUtils.waitfor;
 
 import java.util.ArrayList;
@@ -78,7 +79,7 @@ public class FixedMachineManagerImpl implements MachineManager {
         synchronized (lock) {
             while (!done) {
                 final SpinnakerMachine machine = getLargeEnoughMachine(nBoards);
-                if (machine != null) {
+                if (nonNull(machine)) {
                     // Move the machine from available to allocated
                     machinesAvailable.remove(machine);
                     machinesAllocated.add(machine);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/SpallocMachineManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/SpallocMachineManagerImpl.java
@@ -19,6 +19,8 @@ package uk.ac.manchester.cs.spinnaker.machinemanager;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SNAKE_CASE;
 import static java.util.Arrays.asList;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
@@ -296,7 +298,7 @@ public class SpallocMachineManagerImpl implements MachineManager {
             Response response;
             try {
                 response = responses.poll(TIMEOUT_SECONDS, SECONDS);
-                if (response == null) {
+                if (isNull(response)) {
                     throw new TimeoutException(
                             "No response from spalloc server");
                 }
@@ -308,7 +310,7 @@ public class SpallocMachineManagerImpl implements MachineManager {
                         ((ExceptionResponse) response).getException());
             }
             if (response instanceof ReturnResponse) {
-                if (responseType == null) {
+                if (isNull(responseType)) {
                     return null;
                 }
                 return mapper.readValue(
@@ -352,7 +354,7 @@ public class SpallocMachineManagerImpl implements MachineManager {
         private void readResponse() throws IOException {
             // Note, assumes one response per line
             final String line = reader.readLine();
-            if (line == null) {
+            if (isNull(line)) {
                 synchronized (this) {
                     connected = false;
                     notifyAll();
@@ -682,7 +684,7 @@ public class SpallocMachineManagerImpl implements MachineManager {
 
         if (state.getState() == DESTROYED) {
             final SpinnakerMachine machine = machinesAllocated.remove(job.id);
-            if (machine == null) {
+            if (isNull(machine)) {
                 logger.error("Unrecognized job: {}", job);
                 return;
             }
@@ -752,7 +754,7 @@ public class SpallocMachineManagerImpl implements MachineManager {
         SpallocJob job = null;
         SpinnakerMachine machineAllocated = null;
 
-        while ((job == null) || (machineAllocated == null)) {
+        while (isNull(job) || isNull(machineAllocated)) {
             try {
                 job = startJob(nBoards);
                 machineAllocated = getMachineForJob(job);
@@ -787,7 +789,7 @@ public class SpallocMachineManagerImpl implements MachineManager {
     public void releaseMachine(final SpinnakerMachine machine) {
         final SpallocJob job = jobByMachine.remove(machine);
         try {
-            if (job != null) {
+            if (nonNull(job)) {
                 stopJob(job);
             }
         } catch (final IOException e) {
@@ -810,7 +812,7 @@ public class SpallocMachineManagerImpl implements MachineManager {
     @Override
     public boolean isMachineAvailable(final SpinnakerMachine machine) {
         final SpallocJob job = jobByMachine.get(machine);
-        if (job == null) {
+        if (isNull(job)) {
             return false;
         }
         logger.debug("Job {} still available", job.id);
@@ -821,7 +823,7 @@ public class SpallocMachineManagerImpl implements MachineManager {
     public boolean waitForMachineStateChange(final SpinnakerMachine machine,
             final int waitTime) {
         final SpallocJob job = jobByMachine.get(machine);
-        if (job == null) {
+        if (isNull(job)) {
             return true;
         }
 
@@ -829,7 +831,7 @@ public class SpallocMachineManagerImpl implements MachineManager {
             final JobState state = machineState.get(job.id);
             waitfor(machineState, waitTime);
             final JobState newState = machineState.get(job.id);
-            return (newState != null) && newState.equals(state);
+            return nonNull(newState) && newState.equals(state);
         }
     }
 
@@ -837,7 +839,7 @@ public class SpallocMachineManagerImpl implements MachineManager {
     public void setMachinePower(final SpinnakerMachine machine,
             final boolean powerOn) {
         final SpallocJob job = jobByMachine.get(machine);
-        if (job == null) {
+        if (isNull(job)) {
             return;
         }
         try {
@@ -856,7 +858,7 @@ public class SpallocMachineManagerImpl implements MachineManager {
     public ChipCoordinates getChipCoordinates(final SpinnakerMachine machine,
             final int x, final int y) {
         final SpallocJob job = jobByMachine.get(machine);
-        if (job == null) {
+        if (isNull(job)) {
             return null;
         }
         try {

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/SpallocMachineManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/machinemanager/SpallocMachineManagerImpl.java
@@ -792,7 +792,7 @@ public class SpallocMachineManagerImpl implements MachineManager {
         return machineAllocated;
     }
 
-    private SpallocJob startJob(int nBoards) throws IOException {
+    private SpallocJob startJob(final int nBoards) throws IOException {
         SpallocJob job = createJob(nBoards);
         logger.debug("Got machine {}, requesting notifications", job.id);
         job.notify(true);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/NMPILog.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/NMPILog.java
@@ -20,7 +20,6 @@ package uk.ac.manchester.cs.spinnaker.model;
  * A Neuromorphic Platform Interface log core.
  */
 public class NMPILog {
-
     /**
      * The content of the log.
      */
@@ -42,23 +41,23 @@ public class NMPILog {
     /**
      * Set the content.
      *
-     * @param contentParam The content to set
+     * @param content The content to set
      */
-    public void setContent(final String contentParam) {
-        this.content = new StringBuilder(contentParam);
+    public void setContent(final String content) {
+        this.content = new StringBuilder(content);
     }
 
     /**
      * Append the string to the log.
      *
-     * @param contentParam
+     * @param content
      *            The string to append.
      */
-    public void appendContent(final String contentParam) {
+    public void appendContent(final String content) {
         if (this.content == null) {
-            this.content = new StringBuilder(contentParam);
+            this.content = new StringBuilder(content);
         } else {
-            this.content.append(contentParam);
+            this.content.append(content);
         }
     }
 }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/NMPILog.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/NMPILog.java
@@ -16,6 +16,8 @@
  */
 package uk.ac.manchester.cs.spinnaker.model;
 
+import static java.util.Objects.isNull;
+
 /**
  * A Neuromorphic Platform Interface log core.
  */
@@ -32,7 +34,7 @@ public class NMPILog {
      *         initialised.
      */
     public String getContent() {
-        if (buffer == null) {
+        if (isNull(buffer)) {
             return null;
         }
         return buffer.toString();
@@ -54,7 +56,7 @@ public class NMPILog {
      *            The string to append.
      */
     public void appendContent(final String content) {
-        if (this.buffer == null) {
+        if (isNull(this.buffer)) {
             this.buffer = new StringBuilder(content);
         } else {
             this.buffer.append(content);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/NMPILog.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/model/NMPILog.java
@@ -23,7 +23,7 @@ public class NMPILog {
     /**
      * The content of the log.
      */
-    private StringBuilder content;
+    private StringBuilder buffer;
 
     /**
      * Gets the current log contents.
@@ -32,10 +32,10 @@ public class NMPILog {
      *         initialised.
      */
     public String getContent() {
-        if (content == null) {
+        if (buffer == null) {
             return null;
         }
-        return content.toString();
+        return buffer.toString();
     }
 
     /**
@@ -44,7 +44,7 @@ public class NMPILog {
      * @param content The content to set
      */
     public void setContent(final String content) {
-        this.content = new StringBuilder(content);
+        this.buffer = new StringBuilder(content);
     }
 
     /**
@@ -54,10 +54,10 @@ public class NMPILog {
      *            The string to append.
      */
     public void appendContent(final String content) {
-        if (this.content == null) {
-            this.content = new StringBuilder(content);
+        if (this.buffer == null) {
+            this.buffer = new StringBuilder(content);
         } else {
-            this.content.append(content);
+            this.buffer.append(content);
         }
     }
 }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/nmpi/NMPIQueueManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/nmpi/NMPIQueueManager.java
@@ -46,8 +46,6 @@ import uk.ac.manchester.cs.spinnaker.job.nmpi.QueueEmpty;
 import uk.ac.manchester.cs.spinnaker.job.nmpi.QueueNextResponse;
 import uk.ac.manchester.cs.spinnaker.model.NMPILog;
 import uk.ac.manchester.cs.spinnaker.rest.NMPIQueue;
-import uk.ac.manchester.cs.spinnaker.rest.utils.CustomJacksonJsonProvider;
-import uk.ac.manchester.cs.spinnaker.rest.utils.PropertyBasedDeserialiser;
 
 /**
  * Manages the NMPI queue, receiving jobs and submitting them to be run.
@@ -118,27 +116,6 @@ public class NMPIQueueManager {
      */
     @PostConstruct
     private void initAPIClient() {
-        final CustomJacksonJsonProvider provider =
-                new CustomJacksonJsonProvider();
-
-        /**
-         * How to understand messages coming from the queue.
-         */
-        @SuppressWarnings("serial")
-        class QueueResponseDeserialiser
-                extends PropertyBasedDeserialiser<QueueNextResponse> {
-            /**
-             * Make a deserialiser.
-             */
-            QueueResponseDeserialiser() {
-                super(QueueNextResponse.class);
-                register("id", Job.class);
-                register("warning", QueueEmpty.class);
-            }
-        }
-        provider.addDeserialiser(QueueNextResponse.class,
-                new QueueResponseDeserialiser());
-
         String apiKey = nmpiPassword;
         if (!nmpiPasswordIsApiKey) {
             queue = createBasicClient(nmpiUrl, nmpiUsername, nmpiPassword,
@@ -146,7 +123,7 @@ public class NMPIQueueManager {
             apiKey = queue.getToken(nmpiUsername).getKey();
         }
         queue = createApiKeyClient(nmpiUrl, nmpiUsername, apiKey,
-                NMPIQueue.class, provider);
+                NMPIQueue.class, NMPIQueue.createProvider());
     }
 
     /**

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/nmpi/NMPIQueueManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/nmpi/NMPIQueueManager.java
@@ -136,7 +136,7 @@ public class NMPIQueueManager {
      */
     private Job getJob(final int id) {
         synchronized (jobCache) {
-        	return jobCache.computeIfAbsent(id, queue::getJob);
+            return jobCache.computeIfAbsent(id, queue::getJob);
         }
     }
 
@@ -214,7 +214,7 @@ public class NMPIQueueManager {
      */
     public void appendJobLog(final int id, final String logToAppend) {
         NMPILog existingLog = jobLog.computeIfAbsent(id,
-        		ignored -> new NMPILog());
+                ignored -> new NMPILog());
         existingLog.appendContent(logToAppend);
         logger.debug("Job {} log is being updated", id);
         queue.updateLog(id, existingLog);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/nmpi/NMPIQueueManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/nmpi/NMPIQueueManager.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.cs.spinnaker.nmpi;
 
+import static java.util.Objects.nonNull;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.cs.spinnaker.rest.utils.RestClientUtils.createApiKeyClient;
@@ -254,7 +255,7 @@ public class NMPIQueueManager {
             final ObjectNode provenance) {
         logger.debug("Job {} is finished", id);
 
-        if (logToAppend != null) {
+        if (nonNull(logToAppend)) {
             appendJobLog(id, logToAppend);
         }
 
@@ -296,7 +297,7 @@ public class NMPIQueueManager {
         final StringWriter errors = new StringWriter();
         error.printStackTrace(new PrintWriter(errors));
         final StringBuilder logMessage = new StringBuilder();
-        if (logToAppend != null) {
+        if (nonNull(logToAppend)) {
             logMessage.append(logToAppend);
         }
         if (jobLog.containsKey(id) || (logMessage.length() > 0)) {

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/nmpi/NMPIQueueManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/nmpi/NMPIQueueManager.java
@@ -52,7 +52,7 @@ import uk.ac.manchester.cs.spinnaker.rest.utils.PropertyBasedDeserialiser;
 /**
  * Manages the NMPI queue, receiving jobs and submitting them to be run.
  */
-public class NMPIQueueManager implements Runnable {
+public class NMPIQueueManager {
 
     /**
      * Job status when finished.
@@ -159,12 +159,7 @@ public class NMPIQueueManager implements Runnable {
      */
     private Job getJob(final int id) {
         synchronized (jobCache) {
-            Job job = jobCache.get(id);
-            if (job == null) {
-                job = queue.getJob(id);
-                jobCache.put(id, job);
-            }
-            return job;
+        	return jobCache.computeIfAbsent(id, queue::getJob);
         }
     }
 
@@ -178,8 +173,7 @@ public class NMPIQueueManager implements Runnable {
         listeners.add(listener);
     }
 
-    @Override
-    public void run() {
+    public void processResponsesFromQueue() {
         while (!done) {
             try {
                 // logger.debug("Getting next job");
@@ -242,11 +236,8 @@ public class NMPIQueueManager implements Runnable {
      *            The messages to append
      */
     public void appendJobLog(final int id, final String logToAppend) {
-        NMPILog existingLog = jobLog.get(id);
-        if (existingLog == null) {
-            existingLog = new NMPILog();
-            jobLog.put(id, existingLog);
-        }
+        NMPILog existingLog = jobLog.computeIfAbsent(id,
+        		ignored -> new NMPILog());
         existingLog.appendContent(logToAppend);
         logger.debug("Job {} log is being updated", id);
         queue.updateLog(id, existingLog);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/output/OutputManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/output/OutputManagerImpl.java
@@ -29,6 +29,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.cs.spinnaker.rest.utils.RestClientUtils.createBearerClient;
+import static uk.ac.manchester.cs.spinnaker.utils.ThreadUtils.waitfor;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -115,11 +116,7 @@ public class OutputManagerImpl implements OutputManager {
 
             // Wait until unlocked
             while (locked) {
-                try {
-                    wait();
-                } catch (final InterruptedException e) {
-                    // Do Nothing
-                }
+                waitfor(this);
             }
 
             // Now lock again

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/output/OutputManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/output/OutputManagerImpl.java
@@ -19,6 +19,8 @@ package uk.ac.manchester.cs.spinnaker.output;
 import static java.lang.System.currentTimeMillis;
 import static java.nio.file.Files.move;
 import static java.nio.file.Files.probeContentType;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -223,7 +225,7 @@ public class OutputManagerImpl implements OutputManager {
      * @return The directory of the project
      */
     private File getProjectDirectory(final String projectId) {
-        if ((projectId == null) || projectId.isEmpty()
+        if (isNull(projectId) || projectId.isEmpty()
                 || projectId.endsWith("/")) {
             throw new IllegalArgumentException("bad projectId");
         }
@@ -238,7 +240,7 @@ public class OutputManagerImpl implements OutputManager {
     public List<DataItem> addOutputs(final String projectId, final int id,
             final File baseDirectory, final Collection<File> outputs)
             throws IOException {
-        if (outputs == null) {
+        if (isNull(outputs)) {
             return null;
         }
 
@@ -307,7 +309,7 @@ public class OutputManagerImpl implements OutputManager {
                 if (!download) {
                     final String contentType =
                             probeContentType(resultFile.toPath());
-                    if (contentType != null) {
+                    if (nonNull(contentType)) {
                         logger.debug("File has content type {}", contentType);
                         return ok(resultFile, contentType).build();
                     }
@@ -362,7 +364,7 @@ public class OutputManagerImpl implements OutputManager {
             final UnicoreFileClient fileManager, final String storageId,
             final String filePath) throws IOException {
         final File[] files = directory.listFiles();
-        if (files == null) {
+        if (isNull(files)) {
             return;
         }
         for (final File file : files) {

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/output/OutputManagerImpl.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/output/OutputManagerImpl.java
@@ -22,8 +22,10 @@ import static java.nio.file.Files.probeContentType;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static javax.ws.rs.core.Response.ok;
+import static javax.ws.rs.core.Response.serverError;
+import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.ac.manchester.cs.spinnaker.rest.utils.RestClientUtils.createBearerClient;
@@ -294,15 +296,14 @@ public class OutputManagerImpl implements OutputManager {
         try (JobLock op = new JobLock(idDirectory)) {
             if (purgeFile.exists()) {
                 logger.debug("{} was purged", idDirectory);
-                return Response
-                        .status(NOT_FOUND).entity("Results from job "
-                                + idDirectory.getName() + " have been removed")
+                return status(NOT_FOUND).entity("Results from job "
+                        + idDirectory.getName() + " have been removed")
                         .build();
             }
 
             if (!resultFile.canRead()) {
                 logger.debug("{} was not found", resultFile);
-                return Response.status(NOT_FOUND).build();
+                return status(NOT_FOUND).build();
             }
 
             try {
@@ -311,7 +312,7 @@ public class OutputManagerImpl implements OutputManager {
                             probeContentType(resultFile.toPath());
                     if (contentType != null) {
                         logger.debug("File has content type {}", contentType);
-                        return Response.ok(resultFile, contentType).build();
+                        return ok(resultFile, contentType).build();
                     }
                 }
             } catch (final IOException e) {
@@ -319,7 +320,7 @@ public class OutputManagerImpl implements OutputManager {
                         resultFile, e);
             }
 
-            return Response.ok(resultFile).header("Content-Disposition",
+            return ok(resultFile).header("Content-Disposition",
                     "attachment; filename=" + filename).build();
         }
     }
@@ -401,7 +402,7 @@ public class OutputManagerImpl implements OutputManager {
                 new File(getProjectDirectory(projectId), String.valueOf(id));
         if (!idDirectory.canRead()) {
             logger.debug("{} was not found", idDirectory);
-            return Response.status(NOT_FOUND).build();
+            return status(NOT_FOUND).build();
         }
 
         try {
@@ -413,16 +414,16 @@ public class OutputManagerImpl implements OutputManager {
             }
         } catch (final MalformedURLException e) {
             logger.error("bad user-supplied URL", e);
-            return Response.status(BAD_REQUEST)
+            return status(BAD_REQUEST)
                     .entity("The URL specified was malformed").build();
         } catch (final Throwable e) {
             logger.error("failure in upload", e);
-            return Response.status(INTERNAL_SERVER_ERROR)
+            return serverError()
                     .entity("General error reading or uploading a file")
                     .build();
         }
 
-        return Response.ok().entity("ok").build();
+        return ok("ok").build();
     }
 
     /**

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/remote/web/RemoteSpinnakerBeans.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/remote/web/RemoteSpinnakerBeans.java
@@ -97,13 +97,8 @@ public class RemoteSpinnakerBeans {
     public static ConversionServiceFactoryBean conversionService() {
         final ConversionServiceFactoryBean factory =
                 new ConversionServiceFactoryBean();
-        factory.setConverters(
-                singleton(new Converter<String, SpinnakerMachine>() {
-                    @Override
-                    public SpinnakerMachine convert(final String value) {
-                        return SpinnakerMachine.parse(value);
-                    }
-                }));
+        factory.setConverters(singleton((Converter<String, SpinnakerMachine>)
+                SpinnakerMachine::parse));
         return factory;
     }
 

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/NMPIQueue.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/NMPIQueue.java
@@ -124,7 +124,7 @@ class NMPIQueueResponseDeserialiser
     /**
      * Make a deserialiser.
      */
-	NMPIQueueResponseDeserialiser() {
+    NMPIQueueResponseDeserialiser() {
         super(QueueNextResponse.class);
         register("id", Job.class);
         register("warning", QueueEmpty.class);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/NMPIQueue.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/NMPIQueue.java
@@ -24,10 +24,15 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+
 import uk.ac.manchester.cs.spinnaker.job.nmpi.Job;
+import uk.ac.manchester.cs.spinnaker.job.nmpi.QueueEmpty;
 import uk.ac.manchester.cs.spinnaker.job.nmpi.QueueNextResponse;
 import uk.ac.manchester.cs.spinnaker.model.APIKeyResponse;
 import uk.ac.manchester.cs.spinnaker.model.NMPILog;
+import uk.ac.manchester.cs.spinnaker.rest.utils.CustomJacksonJsonProvider;
+import uk.ac.manchester.cs.spinnaker.rest.utils.PropertyBasedDeserialiser;
 
 /**
  * The REST API for the HBP Neuromorphic Platform Interface queue.
@@ -95,4 +100,33 @@ public interface NMPIQueue {
     @Path("log/{id}")
     @Consumes("application/json")
     void updateLog(@PathParam("id") int id, NMPILog log);
+
+    /**
+     * Create a JSON provider capable of handling the messages on the NMPI
+     * queue.
+     *
+     * @return The provider.
+     */
+    static JacksonJsonProvider createProvider() {
+        CustomJacksonJsonProvider provider = new CustomJacksonJsonProvider();
+        provider.addDeserialiser(QueueNextResponse.class,
+                new NMPIQueueResponseDeserialiser());
+        return provider;
+    }
+}
+
+/**
+ * How to understand messages coming from the queue.
+ */
+@SuppressWarnings("serial")
+class NMPIQueueResponseDeserialiser
+        extends PropertyBasedDeserialiser<QueueNextResponse> {
+    /**
+     * Make a deserialiser.
+     */
+	NMPIQueueResponseDeserialiser() {
+        super(QueueNextResponse.class);
+        register("id", Job.class);
+        register("warning", QueueEmpty.class);
+    }
 }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/ErrorCaptureResponseFilter.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/ErrorCaptureResponseFilter.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.cs.spinnaker.rest.utils;
 
+import static java.util.Objects.nonNull;
 import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 import static javax.ws.rs.core.Response.Status.Family.SERVER_ERROR;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -90,7 +91,7 @@ public class ErrorCaptureResponseFilter implements ClientResponseFilter {
             logger.trace(IND2 + "{}", requestContext.getEntity());
 
             final String json = getRequestAsJSON(requestContext);
-            if (json != null) {
+            if (nonNull(json)) {
                 logger.trace(INDENT + "JSON version:");
                 logger.trace(IND2 + "{}", json);
             }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/NullExceptionMapper.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/NullExceptionMapper.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.cs.spinnaker.rest.utils;
 
+import static java.util.Objects.isNull;
 import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -43,7 +44,7 @@ public class NullExceptionMapper
     @Override
     public Response toResponse(final NullPointerException exception) {
         String msg = exception.getMessage();
-        if ((msg == null) || msg.isEmpty()) {
+        if (isNull(msg) || msg.isEmpty()) {
             msg = "bad parameter";
         }
         logger.info("trapped exception in service method", exception);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/PropertyBasedDeserialiser.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/PropertyBasedDeserialiser.java
@@ -81,9 +81,9 @@ public class PropertyBasedDeserialiser<T> extends StdDeserializer<T> {
         final ObjectNode root = parser.readValueAsTree();
         final Iterator<String> elementsIterator = root.fieldNames();
         while (elementsIterator.hasNext()) {
-            final String name = elementsIterator.next();
-            if (registry.containsKey(name)) {
-                return parser.getCodec().treeToValue(root, registry.get(name));
+            Class<? extends T> c = registry.get(elementsIterator.next());
+            if (c != null) {
+                return parser.getCodec().treeToValue(root, c);
             }
         }
         return null;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/PropertyBasedDeserialiser.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/PropertyBasedDeserialiser.java
@@ -16,6 +16,9 @@
  */
 package uk.ac.manchester.cs.spinnaker.rest.utils;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -64,10 +67,10 @@ public class PropertyBasedDeserialiser<T> extends StdDeserializer<T> {
      */
     public void register(final String propertyName,
             final Class<? extends T> type) {
-        if (propertyName == null) {
+        if (isNull(propertyName)) {
             throw new IllegalArgumentException("propertyName must be non-null");
         }
-        if (type == null) {
+        if (isNull(type)) {
             throw new IllegalArgumentException("type must be non-null");
         }
 
@@ -82,7 +85,7 @@ public class PropertyBasedDeserialiser<T> extends StdDeserializer<T> {
         final Iterator<String> elementsIterator = root.fieldNames();
         while (elementsIterator.hasNext()) {
             Class<? extends T> c = registry.get(elementsIterator.next());
-            if (c != null) {
+            if (nonNull(c)) {
                 return parser.getCodec().treeToValue(root, c);
             }
         }

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/RestClientUtils.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/rest/utils/RestClientUtils.java
@@ -16,6 +16,7 @@
  */
 package uk.ac.manchester.cs.spinnaker.rest.utils;
 
+import static java.util.Objects.nonNull;
 import static org.apache.http.auth.AUTH.WWW_AUTH_RESP;
 
 import java.io.File;
@@ -129,7 +130,7 @@ public abstract class RestClientUtils {
         builder.loadTrustMaterial(new TrustSelfSignedStrategy());
         String trustStore = System.getProperty("remotespinnaker.keystore",
                 null);
-        if (trustStore != null) {
+        if (nonNull(trustStore)) {
             String password = System
                     .getProperty("remotespinnaker.keystore.password", "");
             try {
@@ -170,7 +171,7 @@ public abstract class RestClientUtils {
             client.register(new JacksonJsonProvider());
         }
         ResteasyWebTarget target = client.target(url.toString());
-        if (authorizationHeader != null) {
+        if (nonNull(authorizationHeader)) {
             return target.register((ClientRequestFilter) context -> {
                 context.getHeaders().add(WWW_AUTH_RESP, authorizationHeader);
             }).proxy(clazz);

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/utils/ThreadUtils.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/utils/ThreadUtils.java
@@ -69,7 +69,7 @@ public abstract class ThreadUtils {
      *            The maximum time to wait, in milliseconds
      * @return True if the wait was interrupted, false otherwise
      */
-    public static boolean waitfor(final Object obj, long timeout) {
+    public static boolean waitfor(final Object obj, final long timeout) {
         try {
             obj.wait(timeout);
             return false;

--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/utils/ThreadUtils.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/src/main/java/uk/ac/manchester/cs/spinnaker/utils/ThreadUtils.java
@@ -43,4 +43,38 @@ public abstract class ThreadUtils {
             Thread.currentThread().interrupt();
         }
     }
+
+    /**
+     * Wait for the given object.
+     *
+     * @param obj
+     *            The object to wait for
+     * @return True if the wait was interrupted, false otherwise
+     */
+    public static boolean waitfor(final Object obj) {
+        try {
+            obj.wait();
+            return false;
+        } catch (final InterruptedException e) {
+            return true;
+        }
+    }
+
+    /**
+     * Wait for the given object.
+     *
+     * @param obj
+     *            The object to wait for
+     * @param timeout
+     *            The maximum time to wait, in milliseconds
+     * @return True if the wait was interrupted, false otherwise
+     */
+    public static boolean waitfor(final Object obj, long timeout) {
+        try {
+            obj.wait(timeout);
+            return false;
+        } catch (final InterruptedException e) {
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
This is a batch of changes to make the code actually use Java 8.

In particular:
1. It uses lambda terms (`abcd -> efgh(ij, kl)`) and method references (`abcd::efgh`) in a whole bunch of places to reduce the number of places where we need explicit little helper classes.
2. It uses streams to replace a number of operations.
3. It cleans up a few bits of deprecated API.
4. It deletes a callback interface (and code that used it) that was never implemented anywhere; since there were *never* any instances, there was never going to be any work done through calling via it.