### PR TITLE
Add Java 17 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11, 14]
+        java: [8, 11, 14, 17]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This doesn't update the minimum language profile version, but 17 is a long-term support version.