### PR TITLE
Use a better lock object

### DIFF
--- a/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/JobProcessManager.java
+++ b/RemoteSpiNNaker/RemoteSpiNNakerJobProcessManager/src/main/java/uk/ac/manchester/cs/spinnaker/jobprocessmanager/JobProcessManager.java
@@ -102,7 +102,7 @@ public class JobProcessManager {
         /**
          * An object to synchronise on when sending data.
          */
-        private final Integer sendSync = new Integer(0);
+        private final Object sendSync = new Object();
 
         /**
          * Make a log writer that uploads the log every half second.


### PR DESCRIPTION
Avoids a warning with more recent JDK versions, where direct use of `new Integer(x)` is deprecated (and locking on an `Integer` is weird anyway because of flyweight object sharing).