### PR TITLE
Comment out Spring Security from config

### DIFF
--- a/RemoteSpiNNaker/RemoteSpiNNakerWeb/pom.xml
+++ b/RemoteSpiNNaker/RemoteSpiNNakerWeb/pom.xml
@@ -106,10 +106,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
         </dependency>
+        <!-- NOT CURRENTLY USED
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
         </dependency>
+        -->
         <dependency>
             <groupId>net.java.dev.vcc.thirdparty</groupId>
             <artifactId>xen-api</artifactId>

--- a/RemoteSpiNNaker/pom.xml
+++ b/RemoteSpiNNaker/pom.xml
@@ -30,7 +30,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <resteasy.version>6.2.1.Final</resteasy.version>
         <jackson.version>2.14.1</jackson.version>
+        <!--
         <springsecurity.version>5.7.5</springsecurity.version>
+        -->
         <spring.version>5.3.24</spring.version>
         <slf4j.version>2.0.4</slf4j.version>
         <javadoc.version>3.4.1</javadoc.version>

--- a/RemoteSpiNNaker/pom.xml
+++ b/RemoteSpiNNaker/pom.xml
@@ -127,6 +127,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <artifactId>spring-webmvc</artifactId>
                 <version>${spring.version}</version>
             </dependency>
+            <!-- NOT CURRENTLY USED
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-core</artifactId>
@@ -142,6 +143,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <artifactId>spring-security-config</artifactId>
                 <version>${springsecurity.version}</version>
             </dependency>
+            -->
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>


### PR DESCRIPTION
The code appears to not actually be using Spring Security right now, so this comments it out in the POMs. It does not remove it entirely &mdash; the code may change to use it in the future &mdash; but makes it so that it isn't a maintenance issue.

Makes #259 obsolete... for now.