### PR TITLE
Change to the way that URLs are done for build badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build and Test](https://github.com/SpiNNakerManchester/RemoteSpiNNaker/workflows/Build%20and%20Test/badge.svg?branch=actions)](https://github.com/SpiNNakerManchester/RemoteSpiNNaker/actions?query=workflow%3A%22Build+and+Test%22+branch%3Amaster)
+[![Build and Test](https://github.com/SpiNNakerManchester/RemoteSpiNNaker/actions/workflows/build.yml/badge.svg)](https://github.com/SpiNNakerManchester/RemoteSpiNNaker/actions/workflows/build.yml)
 [![Coverage Status](https://coveralls.io/repos/github/SpiNNakerManchester/RemoteSpiNNaker/badge.svg?branch=master)](https://coveralls.io/github/SpiNNakerManchester/RemoteSpiNNaker?branch=master)
 
 Remote SpiNNaker


### PR DESCRIPTION
Regenerating the badge URLs because it was saying things were failing when they weren't.